### PR TITLE
#167190525 Setup API Documentation Using Swagger

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "Rambo-AuthorsHaven",
+  "name": "rambo-authors-haven",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -987,7 +987,6 @@
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
       "requires": {
         "sprintf-js": "~1.0.2"
       }
@@ -1106,8 +1105,7 @@
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
-      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
-      "dev": true
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c="
     },
     "base": {
       "version": "0.11.2",
@@ -1238,7 +1236,6 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
       "requires": {
         "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
@@ -1554,8 +1551,7 @@
     "concat-map": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
-      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
-      "dev": true
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s="
     },
     "configstore": {
       "version": "3.1.2",
@@ -2757,8 +2753,7 @@
     "fs.realpath": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
-      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
-      "dev": true
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8="
     },
     "fsevents": {
       "version": "1.2.9",
@@ -3357,7 +3352,6 @@
       "version": "7.1.4",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.4.tgz",
       "integrity": "sha512-hkLPepehmnKk41pUGm3sYxoFs/umurYfYJCerbXEyFIWcAzvpipAgVkBqqT9RBKMGjnq6kMuyYwha6csxbiM1A==",
-      "dev": true,
       "requires": {
         "fs.realpath": "^1.0.0",
         "inflight": "^1.0.4",
@@ -3629,7 +3623,6 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
       "requires": {
         "once": "^1.3.0",
         "wrappy": "1"
@@ -3638,8 +3631,7 @@
     "inherits": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "dev": true
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
     },
     "ini": {
       "version": "1.3.5",
@@ -4431,7 +4423,6 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
       "requires": {
         "brace-expansion": "^1.1.7"
       }
@@ -5149,7 +5140,6 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
       "requires": {
         "wrappy": "1"
       }
@@ -5371,8 +5361,7 @@
     "path-is-absolute": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
-      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
-      "dev": true
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18="
     },
     "path-is-inside": {
       "version": "1.0.2",
@@ -6254,8 +6243,7 @@
     "sprintf-js": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
-      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw=",
-      "dev": true
+      "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
     "sshpk": {
       "version": "1.16.1",
@@ -6382,6 +6370,19 @@
       "dev": true,
       "requires": {
         "has-flag": "^3.0.0"
+      }
+    },
+    "swagger-ui-dist": {
+      "version": "3.23.1",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-3.23.1.tgz",
+      "integrity": "sha512-chMAB3JY3tJGLtswyBJGWa5L0nghbImUtFpy2CupswVVC1UsSmVwOI69oOQ1sCxEzQfC2DCu0jUD/x5SjNs+zw=="
+    },
+    "swagger-ui-express": {
+      "version": "4.0.7",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.0.7.tgz",
+      "integrity": "sha512-ipXe53qDMjB2GlFcWARof15fMxX0n0wkwUturBpdovfJLaqod3WAqimwQGFXjwpWKA6hnxEPrd31yOzaYkP++A==",
+      "requires": {
+        "swagger-ui-dist": "^3.18.1"
       }
     },
     "table": {
@@ -7029,8 +7030,7 @@
     "wrappy": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "dev": true
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
     },
     "write": {
       "version": "1.0.3",
@@ -7069,6 +7069,15 @@
       "resolved": "https://registry.npmjs.org/yallist/-/yallist-2.1.2.tgz",
       "integrity": "sha1-HBH5IY8HYImkfdUS+TxmmaaoHVI=",
       "dev": true
+    },
+    "yamljs": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/yamljs/-/yamljs-0.3.0.tgz",
+      "integrity": "sha512-C/FsVVhht4iPQYXOInoxUM/1ELSf9EsgKH34FofQOp6hwCPrW4vG4w5++TED3xRUo8gD7l0P1J1dLlDYzODsTQ==",
+      "requires": {
+        "argparse": "^1.0.7",
+        "glob": "^7.0.5"
+      }
     },
     "yargs": {
       "version": "12.0.5",

--- a/package.json
+++ b/package.json
@@ -6,16 +6,19 @@
   "scripts": {
     "start": "node dist/index.js",
     "start:dev": "nodemon --exec babel-node server/index.js",
-    "build": "babel server --out-dir dist",
+    "build": "babel server --out-dir dist && npm run copy:docs",
     "test": "nyc mocha --timeout 1000 -r esm --exit",
-    "coverage": "nyc report --reporter=text-lcov | coveralls"
+    "coverage": "nyc report --reporter=text-lcov | coveralls",
+    "copy:docs": "cp -r server/docs/ dist/docs/"
   },
   "author": "Andela Simulations Programme",
   "license": "MIT",
   "dependencies": {
     "dotenv": "^8.0.0",
     "express": "^4.17.1",
-    "morgan": "^1.9.1"
+    "morgan": "^1.9.1",
+    "swagger-ui-express": "^4.0.7",
+    "yamljs": "^0.3.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.5.5",

--- a/server/docs/authors-haven-api.yml
+++ b/server/docs/authors-haven-api.yml
@@ -1,0 +1,40 @@
+openapi: 3.0.1
+
+info:
+  title: Authors Haven API Documentation
+  description: Create a community of like minded authors to foster inspiration and innovation by leveraging the modern web.
+  version: 1.0.0
+  contact:
+    email: teamrambo50@gmail.com
+
+license:
+  name: Apache 2.0
+  url: http://www.apache.org/licenses/LICENSE-2.0.html
+
+servers:
+  - url: /
+    desription: Localhost server
+  - url: https://authors-haven-development.herokuapp.com/
+    desription: Heroku development server
+
+paths:
+  /:
+    summary: Represent root of the application
+    description: Represent root of the application.
+    get:
+      summary: Returns a welcome message.
+      description: Returns a welcome message.
+      responses:
+        '200':
+          description: Success
+          content:
+            text/plain:
+              schema:
+                type: string
+                example: Welcome to Authors Haven
+
+components:
+  securitySchemes:
+    BearerAuth:
+      type: http
+      scheme: bearer

--- a/server/index.js
+++ b/server/index.js
@@ -1,17 +1,24 @@
 import express, { json, urlencoded } from 'express';
 import logger from 'morgan';
 import { config } from 'dotenv';
+import swaggerUi from 'swagger-ui-express';
+import YAML from 'yamljs';
+import path from 'path';
 
 config();
 
 const { log } = console;
-
 const PORT = process.env.PORT || 9000;
 
 const app = express();
+const swaggerDoc = YAML.load(
+  path.join(__dirname, './docs/authors-haven-api.yml')
+);
+
 app.use(logger('dev'));
 app.use(json());
-app.use(urlencoded({ extended: false, }));
+app.use(urlencoded({ extended: false }));
+app.use('/api-docs', swaggerUi.serve, swaggerUi.setup(swaggerDoc));
 
 app.get('/', (request, response) => {
   response.status(200).send('Welcome to Authors Haven ');
@@ -20,5 +27,7 @@ app.get('/', (request, response) => {
 app.use('*', (request, response) => {
   response.status(404).send('Not Found');
 });
+
 app.listen(PORT, () => log(`Server started on port ${PORT}`));
+
 export default app;


### PR DESCRIPTION
#### What does this PR do?
- Set up the tool that will be used to document the API endpoints of the application.
- The tool used is Open API Specification (formerly known as Swagger)

#### Description of Task proposed in this pull request?
- Create the file `docs/authors-haven-api.yml` inside the `/server` directory
- Install `swagger-ui-express` NPM package to serve the documentation to a static URL
- Install `yamljs` package to load the `authors-haven-api.yml`

#### How should this be manually tested (Quality Assurance)?
- Run git clone `https://github.com/andela/ah-rambo-backend.git` to clone this repo onto your local machine
- Navigate to the repo directory by running `cd ah-rambo-backend/`
- Ensure your working directory is clean by running git status command
- Get a copy of the PR by typing git fetch origin pull/11/head:ch-setup-api-documentation-167190525
- Now that you have a copy of the branch, switch to it using git checkout ch-setup-api-documentation-167190525
- Your directory will now be an exact copy of the PR
- Open your browser of choice and enter `http://localhost:<port>/api-docs` into your address bar

#### What are the relevant pivotal tracker stories?
- [#167190525](https://www.pivotaltracker.com/story/show/167190525)

#### Any background context you want to add (Operations Impact)?
- Run `npm install` to get all dependencies onto your local machine
- The value of `port` is the port you are running your local server on

#### What I have learned working on this feature:
- I learned how to setup Swagger for API documentation

#### Screenshots:
<img width="1440" alt="Screenshot 2019-07-25 at 8 15 33 PM" src="https://user-images.githubusercontent.com/32547932/61902040-17cf1000-af19-11e9-936e-2c9aa58c8ad1.png">

