### PR TITLE
Fix Bugs with Sign Up Schema

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
   "dependencies": {
     "bcryptjs": "^2.4.3",
     "@hapi/joi": "^15.1.0",
-    "coveralls": "^3.0.5",
     "debug": "^4.1.1",
     "dotenv": "^8.0.0",
     "express": "^4.17.1",

--- a/server/controllers/Users.js
+++ b/server/controllers/Users.js
@@ -25,10 +25,6 @@ class Users {
    */
   static async create(req, res) {
     try {
-      const { password, confirmPassword } = req.body;
-      if (password !== confirmPassword) {
-        return serverResponse(res, 400, { error: 'passwords do not match' });
-      }
       if (await checkEmail(req.body.email)) {
         return serverResponse(res, 409, {
           error: 'email has already been taken'
@@ -39,7 +35,7 @@ class Users {
           error: 'username has already been taken'
         });
       }
-      const hashedPassword = await bcrypt.hash(password, 10);
+      const hashedPassword = await bcrypt.hash(req.body.password, 10);
       const user = await User.create({
         ...req.body,
         password: hashedPassword

--- a/server/helpers/validationHelper.js
+++ b/server/helpers/validationHelper.js
@@ -12,6 +12,12 @@ import { serverResponse } from './serverResponse';
 const setCustomMessage = label => (errors) => {
   errors.forEach((err) => {
     switch (err.type) {
+    case 'any.required':
+      err.message = `${label} is required`;
+      break;
+    case 'any.allowOnly':
+      err.message = `${label} must match password`;
+      break;
     case 'string.alphanum':
       err.message = `${label} should contain only letters and numbers`;
       break;
@@ -28,7 +34,7 @@ const setCustomMessage = label => (errors) => {
       err.message = `${label} should not contain spaces`;
       break;
     default:
-      err.message = `${label} is required`;
+      err.message = `${label} should be a string`;
       break;
     }
   });

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -1,8 +1,9 @@
 import express from 'express';
 import Users from '../controllers/Users';
+import validateUserSignup from '../middlewares/userValidation';
 
 const route = express.Router();
 
-route.post('/create', Users.create);
+route.post('/create', validateUserSignup, Users.create);
 
 export default route;

--- a/server/schemas/userSignup.js
+++ b/server/schemas/userSignup.js
@@ -31,5 +31,9 @@ export default {
     .min(8)
     .max(254)
     .regex(/\s/, { invert: true })
-    .error(setCustomMessage('password'))
+    .error(setCustomMessage('password')),
+  confirmPassword: Joi.string()
+    .required()
+    .valid(Joi.ref('password'))
+    .error(setCustomMessage('confirm password'))
 };

--- a/test/middlewares/userValidation.test.js
+++ b/test/middlewares/userValidation.test.js
@@ -31,8 +31,39 @@ describe('User Signup Validation', () => {
     lastName: 'Haven',
     userName: 'authorshaven',
     email: 'sample.email@authorshaven.com',
-    password: 'sample.email@authorshaven.com'
+    password: 'sample.email@authorshaven.com',
+    confirmPassword: 'sample.email@authorshaven.com'
   };
+
+  it('should return error if any field value is not a string', () => {
+    const invalidUserData = { ...validUserSignupData };
+    invalidUserData.firstName = 123;
+
+    req.body = invalidUserData;
+    validateUserSignup(req, res, next);
+
+    expect(res.statusCode).to.equal(422);
+    expect(res.body).to.haveOwnProperty('errors');
+    expect(res.body.errors).to.haveOwnProperty('firstName');
+    expect(res.body.errors.firstName).to.match(
+      /first name should be a string/i
+    );
+  });
+
+  it('should return error if passwords do not match', () => {
+    const invalidUserData = { ...validUserSignupData };
+    invalidUserData.confirmPassword = 'qwertyui';
+
+    req.body = invalidUserData;
+    validateUserSignup(req, res, next);
+
+    expect(res.statusCode).to.equal(422);
+    expect(res.body).to.haveOwnProperty('errors');
+    expect(res.body.errors).to.haveOwnProperty('confirmPassword');
+    expect(res.body.errors.confirmPassword).to.match(
+      /confirm password must match password/i
+    );
+  });
 
   it('should call the next function if all fields are valid', () => {
     const validUserData = { ...validUserSignupData };

--- a/test/users/_mocks_/index.js
+++ b/test/users/_mocks_/index.js
@@ -8,7 +8,7 @@ const getNewUser = () => {
   const newUser = {
     firstName: faker.name.firstName(),
     lastName: faker.name.lastName(),
-    userName: faker.name.findName(),
+    userName: faker.random.alphaNumeric(10),
     email: faker.internet.email(),
     password: faker.internet.password()
   };

--- a/test/users/signup.test.js
+++ b/test/users/signup.test.js
@@ -34,16 +34,6 @@ describe('POST User', () => {
     expect(response.body.user.email).to.equal(existingEmail);
   });
 
-  it('should return an error if passwords do not match', async () => {
-    const user = getNewUser();
-    const response = await chai
-      .request(app)
-      .post(`${baseUrl}/users/create`)
-      .send(user);
-    expect(response).to.have.status(400);
-    expect(response.body.error).to.equal('passwords do not match');
-  });
-
   it('should not register user with existing email', async () => {
     const user = getNewUser();
     const response = await chai


### PR DESCRIPTION
#### What does this PR do?
- A bug in the schema prevented the sign-up route from working when the middleware was hooked to its controller. This commit fixes it.

#### Description of Task proposed in this pull request?
- This PR adds the `confirmPassword` field to the sign-up validation schema as it is a required field. 

- It checks that the `password` and `confirmPassword` fields are equal.

- It adds the sign-up validation middleware to the route it is for

#### How should this be manually tested (Quality Assurance)?
- Make a request to the `/api/v1/users/create` endpoint and provide:
`{`
`"firstName": "Adeola"`
`"lastName": "Afolabi"`
`"userName": "ade"`
`"email": "ade@gmail.com"`
`"password": "incorrect"`
`"confirmPassword": "incorrect"`
`}`

- Confirm that the request is successful and a new user is created.

#### Any background context you want to add (Operations Impact)?
- Prior to this hot-fix PR, the user validation was not hooked to the sign-up route and if it was hooked, it would have prevented sign-up from being successful

#### What I have learned working on this feature?
- I have learned how to check equality of fields with `Joi` validation library and how to return custom error messages.

#### Screenshots:
<img width="1440" alt="Screenshot 2019-08-01 at 6 13 55 PM" src="https://user-images.githubusercontent.com/42539315/62313258-39d01180-b488-11e9-9af9-bccc88c27f2d.png">

<img width="1440" alt="Screenshot 2019-08-01 at 6 14 02 PM" src="https://user-images.githubusercontent.com/42539315/62313282-47859700-b488-11e9-8880-2868671d7c77.png">


