### PR TITLE
#167190530 Implement User Sign Out

### DIFF
--- a/server/controllers/Sessions.js
+++ b/server/controllers/Sessions.js
@@ -14,7 +14,7 @@ const { Session } = models;
 /**
  *
  *
- * @class Session
+ * @class Sessions
  */
 class Sessions {
   /**
@@ -45,7 +45,7 @@ class Sessions {
       const { devicePlatform, userAgent } = getUserAgent(req);
       const { id, dataValues } = user;
       const expiresAt = expiryDate(devicePlatform);
-      const token = generateToken(id);
+      const token = generateToken({ id });
       await Session.create({
         userId: id,
         token,
@@ -57,6 +57,25 @@ class Sessions {
       res.set('Authorization', token);
       delete dataValues.password;
       return serverResponse(res, 200, { user: { ...dataValues }, token });
+    } catch (error) {
+      serverError(res);
+    }
+  }
+
+  /**
+   *
+   *
+   * @static
+   * @param {object} req - request object
+   * @param {object} res - response object
+   * @memberof Sessions
+   * @returns {json}  object
+   */
+  static async destroy(req, res) {
+    try {
+      const token = req.headers.authorization;
+      await Session.update({ active: false }, { where: { token } });
+      return serverResponse(res, 200, { message: 'sign out successful' });
     } catch (error) {
       serverError(res);
     }

--- a/server/docs/authors-haven-api.yml
+++ b/server/docs/authors-haven-api.yml
@@ -121,6 +121,40 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/fbserverResponse"
+
+  /api/v1/sessions/destroy:
+    get:
+      summary: Sign out Route
+      description: Sign out Route
+      responses:
+        "200":
+          description: Sign out successful
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/signoutResponse"
+        "400":
+          description: Bad request
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        "403":
+          description: Incorrect username or password
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        "500":
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/serverResponse"
+      security:
+        - BearerAuth: []
+
+    
 components:
   securitySchemes:
     BearerAuth:
@@ -210,3 +244,9 @@ components:
       properties:
         message:
           type: string
+    signoutResponse:
+      type: object
+      properties:
+        message:
+          type: string
+

--- a/server/helpers/findToken.js
+++ b/server/helpers/findToken.js
@@ -11,7 +11,7 @@ const findToken = async (param) => {
   const session = await Session.findOne({ active: true }, { where: param });
   if (new Date(Date.now()) >= session.expiresAt) {
     await Session.update({ active: false }, { where: param });
-    return undefined;
+    return false;
   }
 
   return session;

--- a/server/routes/session.js
+++ b/server/routes/session.js
@@ -4,5 +4,6 @@ import Sessions from '../controllers/Sessions';
 const router = express.Router();
 
 router.post('/create', Sessions.create);
+router.get('/destroy', Sessions.destroy);
 
 export default router;

--- a/test/helpers/findToken.test.js
+++ b/test/helpers/findToken.test.js
@@ -10,6 +10,6 @@ describe('verify token middleware', () => {
         'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c'
     };
     const session = await findToken(params);
-    expect(session).to.equal(undefined);
+    expect(session).to.equal(false);
   });
 });


### PR DESCRIPTION
#### What does this PR do?
For a user to properly sign out of the application, the user 's token in the session table is set to inactive to prevent future access to any protected route.

#### Description of Task proposed in this pull request?
- Create destroy session route (signout route) 
**GET**: ```/api/v1/sessions/destroy```
- Add an integration test
- Add route to swagger documentation

#### How should this be manually tested (Quality Assurance)?
- Check out this branch ```ft-implement-user-signout-167190530``` and add the database connection string to your environment variable.
- Use any route testing app to test the route. With any token from the session seeds, add it to the headers 

#### What are the relevant pivotal tracker stories?
- Story ID [#167190530](https://www.pivotaltracker.com/story/show/167190530)

#### Any background context you want to add (Operations Impact)?
- ```npm install``` to install necessary dependencies.
- Add a database connection string to env file
- Access route with **GET**: ```/api/v1/sessions/destroy```

#### What I have learned working on this feature:
-  I learnt more on sequelize and working from PR branches.

#### Screenshots: 
<img width="1124" alt="Screenshot 2019-08-02 at 1 37 15 AM" src="https://user-images.githubusercontent.com/42908597/62336015-3fe4e300-b4c6-11e9-8619-718c3539ebf9.png">


