### PR TITLE
#167706805 Enables an Already Logged In User To Change Their Password 

### DIFF
--- a/server/controllers/Users.js
+++ b/server/controllers/Users.js
@@ -106,6 +106,25 @@ class Users {
       return serverError(res);
     }
   }
+
+  /**
+   * @name changePassword
+   * @async
+   * @static
+   * @memberof Users
+   * @param {Object} req express request object
+   * @param {Object} res express response object
+   * @returns {JSON} JSON object with details of new user
+   */
+  static async changePassword(req, res) {
+    const { password } = req.body;
+    const { id } = req.user.dataValues;
+    const hashedPassword = await bcrypt.hash(password, 10);
+    await User.update({ password: hashedPassword }, { where: { id } });
+    return serverResponse(res, 200, {
+      message: 'password changed successfully'
+    });
+  }
 }
 
 export default Users;

--- a/server/docs/authors-haven-api.yml
+++ b/server/docs/authors-haven-api.yml
@@ -364,6 +364,34 @@ paths:
           description: Success. Email verification was successful
         500:
           description: Internal server errorcomponents     
+
+  /api/v1/users/changePassword:
+    patch:
+      summary: Logged In user can change their password
+      description: Change user password
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/changePasswordDetails'
+      security:
+        - ApiKeyAuth: []
+      responses:
+        "200":
+          description: user password changed successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/changePasswordResponse"
+        "422":
+          description: password does not match validaton errors
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/changePasswordErrorResponse"
+        
+    
 components:
   securitySchemes:
     BearerAuth:
@@ -434,6 +462,18 @@ components:
       token:
         type: string
         example: bhddmdmddddddddddddmddnddb
+  changePasswordDetails:
+    type: object
+    required:
+    - password
+    - confirmPassword
+    properties:
+      password:
+        type: string
+        example: mypassword
+      confirmPassword:
+        type: string
+        example: mypassword
   schemas:
     loginResponse:
       type: object
@@ -582,3 +622,19 @@ components:
                   email:
                     type: string
                     example: abiola@andela.com
+    changePasswordResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: password changed Successfully
+    changePasswordErrorResponse:
+      type: object
+      properties:
+        error:
+          type: object
+          properties:
+            confirmpassword:
+              type: string
+              example: confirm password must match password
+

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -1,6 +1,12 @@
 import { verifyToken, getSessionFromToken } from './verifyToken';
 import validateUserSignup from './userValidation';
+import validateUserPassword from './passwordValidation';
 
-const middlewares = { verifyToken, validateUserSignup, getSessionFromToken };
+const middlewares = {
+  verifyToken,
+  validateUserSignup,
+  getSessionFromToken,
+  validateUserPassword
+};
 
 export default middlewares;

--- a/server/middlewares/passwordValidation.js
+++ b/server/middlewares/passwordValidation.js
@@ -1,0 +1,20 @@
+import Joi from '@hapi/joi';
+import passwordChange from '../schemas/passwordChange';
+import { validateInputs } from '../helpers';
+
+const options = {
+  abortEarly: false
+};
+
+/**
+ * Validates user registration/signup input
+ *
+ * @param {string} req - ExpressJs request object
+ * @param {string} res - ExpressJs response object
+ * @param {string} next - ExpressJs next function
+ * @returns {(JSON|function)} HTTP JSON response or ExpressJs next function
+ */
+const validateUserPassword = (req, res, next) => {
+  Joi.validate(req.body, passwordChange, options, validateInputs(res, next));
+};
+export default validateUserPassword;

--- a/server/routes/user.js
+++ b/server/routes/user.js
@@ -4,10 +4,21 @@ import middlewares from '../middlewares';
 
 const route = express.Router();
 
-const { validateUserSignup, verifyToken } = middlewares;
+const {
+  verifyToken,
+  validateUserPassword,
+  validateUserSignup,
+  getSessionFromToken
+} = middlewares;
 
 route.post('/create', validateUserSignup, Users.create);
 route.get('/verifyEmail/:token', verifyToken, Users.verifyUserEmail);
 route.get('/verificationEmail/:email', Users.resendVerificationEmail);
-
+route.patch(
+  '/changePassword',
+  verifyToken,
+  getSessionFromToken,
+  validateUserPassword,
+  Users.changePassword
+);
 export default route;

--- a/server/schemas/passwordChange.js
+++ b/server/schemas/passwordChange.js
@@ -1,0 +1,15 @@
+import Joi from '@hapi/joi';
+import { setCustomMessage } from '../helpers';
+
+export default {
+  password: Joi.string()
+    .required()
+    .min(8)
+    .max(254)
+    .regex(/\s/, { invert: true })
+    .error(setCustomMessage('password')),
+  confirmPassword: Joi.string()
+    .required()
+    .valid(Joi.ref('password'))
+    .error(setCustomMessage('confirm password'))
+};

--- a/test/middlewares/userValidation.test.js
+++ b/test/middlewares/userValidation.test.js
@@ -1,10 +1,10 @@
 /* eslint-disable max-len */
 import chai from 'chai';
 import sinon from 'sinon';
-import validateUserSignup from '../../server/middlewares/userValidation';
+import validation from '../../server/middlewares';
 
 const { expect } = chai;
-
+const { validateUserSignup } = validation;
 // ExpressJs req, res, and next mocks
 const next = sinon.stub();
 const req = {};

--- a/test/users/__mocks__/passwordReset.js
+++ b/test/users/__mocks__/passwordReset.js
@@ -1,0 +1,11 @@
+const matchPassword = {
+  password: 'authorsHaven',
+  confirmPassword: 'authorsHaven'
+};
+
+const conflictPassword = {
+  password: 'conflicting',
+  confirmPassword: 'conflictingYes'
+};
+
+export { matchPassword, conflictPassword };

--- a/test/users/index.js
+++ b/test/users/index.js
@@ -2,7 +2,8 @@ import * as signUp from './signup.test';
 import * as sessions from './sessions.test';
 import * as verifyEmail from './emailVerify.test';
 import * as resendEmails from './resendVerifyEmail';
+import * as passwordChange from './passwordChange.test';
 
 export {
-  signUp, sessions, verifyEmail, resendEmails
+  signUp, sessions, verifyEmail, resendEmails, passwordChange
 };

--- a/test/users/passwordChange.test.js
+++ b/test/users/passwordChange.test.js
@@ -1,0 +1,61 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import { config } from 'dotenv';
+import app from '../../server';
+import { matchPassword, conflictPassword } from './__mocks__/passwordReset';
+
+config();
+
+chai.use(chaiHttp);
+
+const baseUrl = process.env.BASE_URL;
+let userToken;
+describe('POST User', () => {
+  it('should sign up a new user', async () => {
+    const response = await chai
+      .request(app)
+      .post(`${baseUrl}/users/create`)
+      .send({
+        firstName: 'firstName',
+        lastName: 'lastname',
+        userName: 'adeRambo',
+        email: 'Rambo@gmail.com',
+        password: 'conflictingNo',
+        confirmPassword: 'conflictingNo'
+      });
+    const { token } = response.body;
+    userToken = token;
+    expect(response).to.have.status(201);
+    expect(response.body).to.be.an('object');
+  });
+
+  context(
+    `when a registered user wants to change thier 
+  password with non-conflicting password`,
+    () => {
+      it('it reset the users password', async () => {
+        const response = await chai
+          .request(app)
+          .patch(`${baseUrl}/users/changePassword`)
+          .send({ ...matchPassword })
+          .set('Authorization', userToken);
+        expect(response).to.have.status(200);
+      });
+    }
+  );
+
+  context(
+    `when a registered user wants to change thier 
+  password with conflicting password`,
+    () => {
+      it('will not reset the users password', async () => {
+        const response = await chai
+          .request(app)
+          .patch(`${baseUrl}/users/changePassword`)
+          .send({ ...conflictPassword })
+          .set('Authorization', userToken);
+        expect(response).to.have.status(422);
+      });
+    }
+  );
+});


### PR DESCRIPTION
#### What does this PR do?
This PR enables signed-in user to change their password
#### Description of Task proposed in this pull request?

A user controller responsible for updating the user's password and validations for password

#### How should this be manually tested (Quality Assurance)?
```
npm install
npm start:dev
patch localhost:5000/api/v1/users/changePassword
add the following in the request body

{
	"password": "mypassword",
	"confirmPassword": "mypassword"
}

```

#### What are the relevant pivotal tracker stories?
- [167706805](https://www.pivotaltracker.com/story/show/167706805)

#### What I have learned working on this feature:
- I learnt how to reset user password and validate user data

#### Screenshots: 
<img width="942" alt="Screenshot 2019-08-08 at 8 38 19 PM" src="https://user-images.githubusercontent.com/44194416/62732545-87b2bf80-ba1c-11e9-81d9-238d1cf27b4b.png">
<img width="1208" alt="Screenshot 2019-08-08 at 8 39 26 PM" src="https://user-images.githubusercontent.com/44194416/62732598-ab760580-ba1c-11e9-903a-f8209339ac44.png">



