### PR TITLE
#167807720 Fix Enables Social User to be verified by default

### DIFF
--- a/server/helpers/createSocialUsers.js
+++ b/server/helpers/createSocialUsers.js
@@ -25,7 +25,8 @@ const createSocialUser = async (data) => {
     defaults: {
       firstName,
       lastName,
-      email
+      email,
+      verified: true
     }
   });
   const result = { ...users[0].dataValues };

--- a/test/auth/__mocks_/index.js
+++ b/test/auth/__mocks_/index.js
@@ -67,6 +67,22 @@ const profile = {
   error: 'Auth failed'
 };
 
+const verifiedStatusData = {
+  firstName: 'verifiedTest',
+  lastName: 'verified',
+  email: 'verified@gmail.com',
+  ipAddress: '168.212.226.204',
+  userAgent: `Mozilla/5.0 (Macintosh; Intel Mac OS X 10_14_2)
+    AppleWebKit/537.36 (KHTML, like Gecko) Chrome/75.0.3770.142 Safari/537.36`,
+  devicePlatform: 'mobile'
+};
+
 export {
-  request, request3, request2, users, mockrequest, profile
+  request,
+  request3,
+  request2,
+  users,
+  mockrequest,
+  profile,
+  verifiedStatusData
 };

--- a/test/auth/index.js
+++ b/test/auth/index.js
@@ -1,5 +1,8 @@
 import * as facebookTest from './facebook.test';
 import * as googleTest from './google.test';
 import * as twitterTest from './twitter.test';
+import * as verifySocialUser from './verifySocialUser.test';
 
-export { facebookTest, googleTest, twitterTest };
+export {
+  facebookTest, googleTest, twitterTest, verifySocialUser
+};

--- a/test/auth/verifySocialUser.test.js
+++ b/test/auth/verifySocialUser.test.js
@@ -1,0 +1,47 @@
+import chai from 'chai';
+import sinon from 'sinon';
+import CreateSocialUser from '../../server/helpers/createSocialUsers';
+import { verifiedStatusData } from './__mocks_';
+import PassportError from '../../server/middlewares/passportError';
+
+const req = {};
+const res = {
+  body: null,
+  statusCode: null,
+  send(data) {
+    this.body = data;
+    return data;
+  },
+  json(data) {
+    this.body = data;
+    return data;
+  },
+  status(responseStatus) {
+    this.statusCode = responseStatus;
+    return this;
+  }
+};
+const { expect } = chai;
+describe('verified Status on Social login test', () => {
+  context(
+    `when a user supplies valid credential to each
+  of the socialLogin api`,
+    () => {
+      it('verifies such user successfully', async () => {
+        const response = await CreateSocialUser(verifiedStatusData);
+        const { verified } = response;
+        expect(verified).to.be.equal(true);
+      });
+    }
+  );
+  context(
+    'when user does not supply valid credential to the Social login api',
+    () => {
+      it('returns an error message on failure', () => {
+        PassportError.passportErrors(true, req, res, () => {});
+        expect(res.body.message).to.equals('Auth failed');
+        expect(res.statusCode).to.equals(400);
+      });
+    }
+  );
+});


### PR DESCRIPTION
#### What does this PR do?
This Fix Enables a social user to be verified by default

#### Description of Task proposed in this pull request?
The create SocialUser helper was adjusted to verify social user by default

#### How should this be manually tested (Quality Assurance)?
```
localhost:5000/api/v1/auth/google
localhost:5000/api/v1/auth/twitter
localhost:5000/api/v1/auth/facebook

```

#### What are the relevant pivotal tracker stories?
- [167807720](https://www.pivotaltracker.com/story/show/167807720)



#### What I have learned working on this feature: 
- I learned how identify and raise a bug fix

#### Screenshots:
<img width="1369" alt="Screenshot 2019-08-09 at 2 25 51 PM" src="https://user-images.githubusercontent.com/44194416/62782206-a6af6100-bab1-11e9-96ca-4ce7dae79ffd.png">

