### PR TITLE
Add Active Session Finder Middleware to Protected Routes

### DIFF
--- a/server/controllers/Sessions.js
+++ b/server/controllers/Sessions.js
@@ -46,15 +46,6 @@ class Sessions {
       const { id, dataValues } = user;
       const expiresAt = expiryDate(devicePlatform);
       const token = generateToken({ id });
-      const validityPeriod = Date.now() - 24 * 360000;
-      const isValid = validityPeriod < Date.parse(user.createdAt);
-      if (!isValid && !user.verified) {
-        await Session.update({ active: false }, { where: { userId: user.id } });
-        return serverResponse(res, 403, {
-          error: 'please verify your email address',
-          email: user.email
-        });
-      }
       await Session.create({
         userId: id,
         token,

--- a/server/middlewares/checkUserVerification.js
+++ b/server/middlewares/checkUserVerification.js
@@ -1,0 +1,23 @@
+import { serverResponse } from '../helpers';
+
+/**
+ * @name checkUserVerification
+ * @async
+ * @param {Object} req express request object
+ * @param {Object} res express response object
+ * @param {Function} next function that calls next middleware
+ * @returns {Function} calls the next middleware
+ */
+const checkUserVerification = async (req, res, next) => {
+  const { user } = req;
+  const newUserPeriod = Date.now() - 24 * 3600000;
+  const isNotNewUser = Date.parse(user.createdAt) < newUserPeriod;
+  if (isNotNewUser && !user.verified) {
+    return serverResponse(res, 403, {
+      error: 'please verify your email address'
+    });
+  }
+  next();
+};
+
+export default checkUserVerification;

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -2,13 +2,15 @@ import { verifyToken, getSessionFromToken } from './verifyToken';
 import validateUserSignup from './userValidation';
 import validateUserPassword from './passwordValidation';
 import validateProfileEdit from './profileValidation';
+import checkUserVerification from './checkUserVerification';
 
 const middlewares = {
   verifyToken,
   validateUserSignup,
   getSessionFromToken,
   validateUserPassword,
-  validateProfileEdit
+  validateProfileEdit,
+  checkUserVerification
 };
 
 export default middlewares;

--- a/server/routes/follower.js
+++ b/server/routes/follower.js
@@ -1,10 +1,20 @@
 import express from 'express';
 import Followers from '../controllers/Followers';
-import { verifyToken } from '../middlewares/verifyToken';
+import { verifyToken, getSessionFromToken } from '../middlewares/verifyToken';
 
 const route = express.Router();
 
-route.post('/:username/follow', verifyToken, Followers.follow);
-route.delete('/:username/follow', verifyToken, Followers.unfollow);
+route.post(
+  '/:username/follow',
+  verifyToken,
+  getSessionFromToken,
+  Followers.follow
+);
+route.delete(
+  '/:username/follow',
+  verifyToken,
+  getSessionFromToken,
+  Followers.unfollow
+);
 
 export default route;

--- a/server/routes/userFollower.js
+++ b/server/routes/userFollower.js
@@ -1,10 +1,20 @@
 import express from 'express';
 import Followers from '../controllers/Followers';
-import { verifyToken } from '../middlewares/verifyToken';
+import { verifyToken, getSessionFromToken } from '../middlewares/verifyToken';
 
 const route = express.Router();
 
-route.get('/followers', verifyToken, Followers.allFollowers);
-route.get('/followings', verifyToken, Followers.allFollowings);
+route.get(
+  '/followers',
+  verifyToken,
+  getSessionFromToken,
+  Followers.allFollowers
+);
+route.get(
+  '/followings',
+  verifyToken,
+  getSessionFromToken,
+  Followers.allFollowings
+);
 
 export default route;

--- a/test/middlewares/checkUserVerification.test.js
+++ b/test/middlewares/checkUserVerification.test.js
@@ -1,0 +1,79 @@
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import { getNewUser } from '../users/__mocks__';
+import app from '../../server';
+import middlewares from '../../server/middlewares';
+import models from '../../server/database/models';
+
+const { checkUserVerification } = middlewares;
+
+chai.use(chaiHttp);
+
+const { BASE_URL } = process.env;
+
+const { User } = models;
+
+describe("Check User's Email Verification", () => {
+  let newUser;
+  before(async () => {
+    const user = getNewUser();
+    const createdUser = await chai
+      .request(app)
+      .post(`${BASE_URL}/users/create`)
+      .send({ ...user, confirmPassword: user.password });
+    newUser = createdUser.body.user;
+  });
+  context('when any user makes a request before validity expiry', () => {
+    it('calls the next middleware', async () => {
+      const request = { headers: {}, user: newUser };
+      const response = { status() {}, json() {} };
+      const next = sinon.spy();
+      sinon.stub(response, 'status').returnsThis();
+      sinon.stub(response, 'json').returns({});
+      await checkUserVerification(request, response, next);
+    });
+  });
+
+  context('when an unverified user makes a request after expiry', () => {
+    it('returns an error', async () => {
+      newUser.createdAt = new Date(Date.now() - 25 * 3600000);
+      const request = { headers: {}, user: newUser };
+      const response = { status() {}, json() {} };
+      const next = sinon.spy();
+      const status = sinon.stub(response, 'status').returnsThis();
+      sinon.stub(response, 'json').returns({});
+      await checkUserVerification(request, response, next);
+      expect(status).to.calledWith(403);
+    });
+  });
+
+  context('when a verified user makes a request before expiry', () => {
+    it('calls the next middleware', async () => {
+      newUser = {
+        ...newUser,
+        verified: true,
+        createdAt: new Date(Date.now() - 2 * 3600000)
+      };
+      const request = { headers: {}, user: newUser };
+      const response = { status() {}, json() {} };
+      const next = sinon.spy();
+      sinon.stub(response, 'status').returnsThis();
+      sinon.stub(response, 'json').returns({});
+      await checkUserVerification(request, response, next);
+    });
+  });
+
+  context('when a verified user makes a request after expiry', () => {
+    it('calls the next middleware', async () => {
+      newUser.createdAt = new Date(Date.now() - 26 * 3600000);
+      const request = { headers: {}, user: newUser };
+      const response = { status() {}, json() {} };
+      await User.update({ verified: true }, { where: { id: newUser.id } });
+      const next = sinon.spy();
+      sinon.stub(response, 'status').returnsThis();
+      sinon.stub(response, 'json').returns({});
+      await checkUserVerification(request, response, next);
+    });
+  });
+});

--- a/test/middlewares/index.js
+++ b/test/middlewares/index.js
@@ -1,5 +1,11 @@
 import * as verifyToken from './verifyToken.test';
 import * as userValidation from './userValidation.test';
 import * as profileValidation from './profileValidation.test';
+import * as checkUserVerification from './checkUserVerification.test';
 
-export default { verifyToken, userValidation, profileValidation };
+export default {
+  verifyToken,
+  userValidation,
+  profileValidation,
+  checkUserVerification
+};

--- a/test/users/sessions.test.js
+++ b/test/users/sessions.test.js
@@ -103,33 +103,6 @@ describe('LOGIN TEST', () => {
   });
 });
 
-context("when user isn't verified and was registered above 24 hours", () => {
-  let newUser;
-  let user;
-  before(async () => {
-    user = getNewUser();
-    newUser = await chai
-      .request(app)
-      .post('/api/v1/users/create')
-      .send({ ...user, confirmPassword: user.password });
-  });
-
-  it('returns an error', async () => {
-    const newRegTime = Date.now() - 25 * 360000;
-    const { email, id } = newUser.body.user;
-    await User.update({ createdAt: newRegTime }, { where: { id } });
-    const response = await chai
-      .request(app)
-      .post(`${LOGIN_URL}`)
-      .send({
-        userLogin: email,
-        password: user.password
-      });
-    expect(response).to.have.status(403);
-    expect(response.body.error).to.equal('please verify your email address');
-  });
-});
-
 describe('LOGIN SERVER ERROR TEST', () => {
   it("should not login in user if there's a server error", async () => {
     const stubfunc = { create };


### PR DESCRIPTION
#### What does this PR do?
- The middlewares for verifying a token and getting active sessions were split. This PR adds the active sessions middleware to the routes that need it and separates user verification into a middleware for future use

#### Description of Task proposed in this pull request?
- The `getSessionsFromToken` middleware was added to the `followers` and `userFollowings` routes from which they were absent

- The email verification that terminated session creation after 24 hours was moved to a middleware that can be used for other middlewares that need it.

- The email verification check was removed from the `createSession` controller

#### How should this be manually tested (Quality Assurance)?
- Due to the bug introduced by a previous PR, expired tokens could be used to make requests on protected routes and this PR fixes that. To test this feature, send a token in the authorization headers to the `/api/v1/sessions/destroy` endpoint and then use that same token to access the `/api/v1/profiles/:userName/follow`. The user will get a JSON response informing them that the session has expired.

#### Any background context you want to add (Operations Impact)?
- This PR does not add any new dependency to the project. It should only be noted that it also removes checks for verification when users try to create new sessions.

#### What I have learned working on this feature:
- I learned how to think holistically

#### Screenshots: 
<img width="1440" alt="Screenshot 2019-08-10 at 7 23 18 AM" src="https://user-images.githubusercontent.com/42539315/62818488-d3aa5500-bb3f-11e9-881f-9530b1019f2a.png">
