### PR TITLE
#167918277 Implement Create Category Functionality

### DIFF
--- a/server/controllers/Categories.js
+++ b/server/controllers/Categories.js
@@ -1,0 +1,42 @@
+import models from '../database/models';
+import { serverResponse, serverError } from '../helpers';
+
+const { Category } = models;
+
+/**
+ * @export
+ * @class Categories
+ */
+class Categories {
+  /**
+   * @name create
+   * @async
+   * @static
+   * @memberof Categories
+   * @param {Object} req express request object
+   * @param {Object} res express response object
+   * @returns {Json} server response
+   */
+  static async create(req, res) {
+    try {
+      const { description } = req.body;
+      const name = req.body.name.toLowerCase();
+      const existingCategory = await Category.findByName(name);
+      if (existingCategory) {
+        return serverResponse(res, 409, {
+          error: `${name} category already exists`
+        });
+      }
+      const newCategory = await Category.create({ name, description });
+
+      return serverResponse(res, 200, {
+        message: `${name} category successfully created`,
+        data: newCategory.dataValues
+      });
+    } catch (error) {
+      serverError(res);
+    }
+  }
+}
+
+export default Categories;

--- a/server/database/migrations/20190731135155-create-category.js
+++ b/server/database/migrations/20190731135155-create-category.js
@@ -10,6 +10,11 @@ export default {
       type: Sequelize.STRING,
       allowNull: false
     },
+    description: {
+      type: Sequelize.STRING(100),
+      allowNull: false,
+      defaultValue: ''
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/server/database/models/category.js
+++ b/server/database/models/category.js
@@ -6,6 +6,11 @@ export default (sequelize, DataTypes) => {
         allowNull: false,
         type: DataTypes.STRING,
         unique: true
+      },
+      description: {
+        allowNull: false,
+        type: DataTypes.STRING(100),
+        defaultValue: ''
       }
     },
     {}

--- a/server/database/seeds/20190730180408-my-seed-file.js
+++ b/server/database/seeds/20190730180408-my-seed-file.js
@@ -56,12 +56,14 @@ export default {
       },
       {
         firstName: 'demo',
-        lastName: 'user',
+        lastName: 'User',
         userName: 'demoUser',
         email: 'demoUser@gmail.com',
         password:
-            '$2y$12$3t1adkk7/grjsz2cG5hlXOTO8LwZUmGeG7zs6udoH78MeoPNmXQ.y',
-        bio: 'This is a simple bio of demo user',
+            '$2a$10$0dVjZKAHBb6Lg.dnujRwme1WbhMAfCIj02uptPxO.u5gNIi5DoqtW',
+        avatarUrl:
+            'https://res.cloudinary.com/teamrambo50/image/upload/v1565160704/avatar-1577909_1280_xsoxql.png',
+        bio: 'This is a simple bio of Escanor the sin of pride',
         role: 'superadmin',
         level: 5,
         followingsCount: 1,

--- a/server/docs/authors-haven-api.yml
+++ b/server/docs/authors-haven-api.yml
@@ -548,7 +548,6 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/serverResponse"                    
-          description: Internal server error
   /api/v1/articles/create:
     post:
       summary: A user can create an article
@@ -570,6 +569,8 @@ paths:
                 image:
                   type: string
                   format: binary
+                tags:
+                  type: string
       security:
         - ApiKeyAuth: []
       responses:
@@ -614,14 +615,12 @@ paths:
       responses:
         201:
           description: Comment Added
-
         404:
           description: Article not found
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/errorResponse"
-
         422:
           description: comment validation error
           content:
@@ -634,9 +633,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/serverResponse"  
-
-    /api/v1/articles/{slug}/comments:
+                "$ref": "#/components/schemas/serverResponse"
     get:
       parameters:
         - in: path
@@ -661,8 +658,51 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/serverResponse" 
+                "$ref": "#/components/schemas/serverResponse"   
 
+  /api/v1/categories/create:
+    post:
+      summary: Logged In admin user can create a category
+      description: Create category
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createCategory'
+      responses:
+        200:
+          description: category successfully created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/createCategoryResponse"
+        401:
+          description: token expired
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        404:
+          description: user not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        409:
+          description: category already exists
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        500:
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/serverResponse"
                      
 components:
   securitySchemes:
@@ -1024,13 +1064,26 @@ components:
             status:
               type: string
               example: status is required
-          
-          
-      
-
-        
-
-
-
-
-
+    createCategory:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: newCategoryy
+    createCategoryResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: newCategoryy category successfully created
+        data:
+          type: object
+          properties:
+            id: 
+              type: integer
+              example: 3
+            name:
+              type: string
+              example: newCategoryy

--- a/server/middlewares/createCategoryValidation.js
+++ b/server/middlewares/createCategoryValidation.js
@@ -1,0 +1,21 @@
+import Joi from '@hapi/joi';
+import { category } from '../schemas';
+import { validateInputs } from '../helpers';
+
+/**
+ * Validates user inputs when he/she edit his/her profile
+ *
+ * @param {Object} req - ExpressJs request object
+ * @param {Object} res - ExpressJs response object
+ * @param {Function} next - ExpressJs next function
+ * @returns {(JSON|Function)} HTTP JSON response or ExpressJs next function
+ */
+const validateProfileEdit = (req, res, next) => {
+  const options = {
+    abortEarly: false
+  };
+
+  Joi.validate(req.body, category, options, validateInputs(res, next));
+};
+
+export default validateProfileEdit;

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -9,6 +9,7 @@ import validatePagination from './paginationValidation';
 import validateArticle from './articleValidation';
 import authorizeUser from './authorizeUser';
 import validateCommentBody from './commentValidation';
+import createCategoryValidation from './createCategoryValidation';
 
 const middlewares = {
   verifyToken,
@@ -22,7 +23,8 @@ const middlewares = {
   validateResetPassword,
   validatePagination,
   authorizeUser,
-  validateCommentBody
+  validateCommentBody,
+  createCategoryValidation
 };
 
 export default middlewares;

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import Categories from '../controllers/Categories';
+import middlewares from '../middlewares';
+
+const route = express.Router();
+const {
+  authorizeUser,
+  verifyToken,
+  createCategoryValidation,
+  getSessionFromToken
+} = middlewares;
+
+route.post(
+  '/create',
+  verifyToken,
+  getSessionFromToken,
+  authorizeUser(4),
+  createCategoryValidation,
+  Categories.create
+);
+
+export default route;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,6 +8,7 @@ import profile from './profile';
 import article from './article';
 import tag from './tag';
 import comment from './comment';
+import category from './category';
 
 const route = express.Router();
 
@@ -18,7 +19,7 @@ route.use('/profiles', profile, follower);
 route.use('/user', userFollower);
 route.use('/articles', article);
 route.use('/tags', tag);
-route.use('/articles', comment);
 route.use('/articles', article, comment);
+route.use('/categories', category);
 
 export default route;

--- a/server/schemas/category.js
+++ b/server/schemas/category.js
@@ -1,0 +1,17 @@
+import Joi from '@hapi/joi';
+import { setCustomMessage } from '../helpers';
+
+export default {
+  name: Joi.string()
+    .required()
+    .min(2)
+    .max(20)
+    .regex(/\w/)
+    .error(setCustomMessage('category name')),
+  description: Joi.string()
+    .optional()
+    .min(2)
+    .max(100)
+    .regex(/\w/)
+    .error(setCustomMessage('category description'))
+};

--- a/server/schemas/index.js
+++ b/server/schemas/index.js
@@ -3,7 +3,13 @@ import profileEdit from './profileEdit';
 import paginationSchema from './pagination';
 import article from './article';
 import comment from './comment';
+import category from './category';
 
 export {
-  userSignup, profileEdit, article, paginationSchema, comment
+  userSignup,
+  profileEdit,
+  category,
+  article,
+  paginationSchema,
+  comment
 };

--- a/test/categories/createCategory.test.js
+++ b/test/categories/createCategory.test.js
@@ -1,0 +1,77 @@
+/* eslint-disable max-len */
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import app from '../../server';
+import Categories from '../../server/controllers/Categories';
+
+chai.use(chaiHttp);
+
+const { BASE_URL } = process.env;
+const { create } = Categories;
+
+let data;
+before(async () => {
+  const response = await chai
+    .request(app)
+    .post(`${BASE_URL}/sessions/create`)
+    .send({
+      userLogin: 'demoUser',
+      password: 'incorrect'
+    });
+  data = response.body;
+});
+
+describe('Create Categories Test', () => {
+  context('when a new category name is present', () => {
+    it('creates a new category', async () => {
+      const response = await chai
+        .request(app)
+        .post(`${BASE_URL}/categories/create`)
+        .set('Authorization', data.token)
+        .send({
+          name: 'demographically',
+          description: 'demograph of the world'
+        });
+      expect(response).to.have.status(200);
+      expect(response.body).to.have.key('message', 'data');
+      expect(response.body.data.name).to.equal('demographically');
+      expect(response.body.data.description).to.be.a('string');
+    });
+  });
+
+  context('when an existing category name is supplied', () => {
+    it('throws an error', async () => {
+      const response = await chai
+        .request(app)
+        .post(`${BASE_URL}/categories/create`)
+        .set('Authorization', data.token)
+        .send({
+          name: 'demographically',
+          description: 'demograph of the world'
+        });
+      expect(response).to.have.status(409);
+      expect(response.body).to.have.key('error');
+      expect(response.body.error).to.equal(
+        'demographically category already exists'
+      );
+    });
+  });
+
+  context('when the create method encounters a internal error', () => {
+    it('throws a server error', async () => {
+      const stubfunc = { create };
+      const sandbox = sinon.createSandbox();
+      sandbox.stub(stubfunc, 'create').rejects(new Error('Server Error'));
+
+      const next = sinon.spy();
+      const res = {
+        status: () => ({
+          json: next
+        })
+      };
+      await create({}, res);
+      sinon.assert.calledOnce(next);
+    });
+  });
+});

--- a/test/categories/index.js
+++ b/test/categories/index.js
@@ -1,0 +1,3 @@
+import * as createCategory from './createCategory.test';
+
+export default createCategory;

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,7 @@ import './profiles';
 import './articles';
 import './tags';
 import './comments';
+import './categories';
 
 const { expect } = chai;
 chai.use(chaiHttp);

--- a/test/middlewares/createCategoryValidation.test.js
+++ b/test/middlewares/createCategoryValidation.test.js
@@ -1,0 +1,109 @@
+/* eslint-disable max-len */
+import chai from 'chai';
+import sinon from 'sinon';
+import validateProfileEdit from '../../server/middlewares/createCategoryValidation';
+import { sampleCategory } from '../users/__mocks__';
+
+const { expect } = chai;
+
+const next = sinon.stub();
+const req = {};
+const res = {
+  body: null,
+  statusCode: null,
+  send(data) {
+    this.body = data;
+    return data;
+  },
+  json(data) {
+    this.body = data;
+    return data;
+  },
+  status(responseStatus) {
+    this.statusCode = responseStatus;
+    return this;
+  }
+};
+
+describe('Create Category Validation Middleware', () => {
+  const validCategory = sampleCategory();
+
+  context('when the name is not given', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      delete invalidCategory.name;
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('name');
+      expect(res.body.errors.name).to.match(/category name is required/i);
+    });
+  });
+
+  context('when the name is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.name = '///';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('name');
+      expect(res.body.errors.name).to.match(/category name is invalid/i);
+    });
+  });
+
+  context('when the description is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.description = '///';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('description');
+      expect(res.body.errors.description).to.match(
+        /category description is invalid/i
+      );
+    });
+  });
+
+  context('when the name is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.name = '';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('name');
+      expect(res.body.errors.name).to.match(/category name is invalid/i);
+    });
+  });
+
+  context('when the description is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.description = '';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('description');
+      expect(res.body.errors.description).to.match(
+        /category description is invalid/i
+      );
+    });
+  });
+});

--- a/test/middlewares/index.js
+++ b/test/middlewares/index.js
@@ -5,6 +5,7 @@ import * as checkUserVerification from './checkUserVerification.test';
 import * as paginationValidation from './paginationValidation.test';
 import * as authorizeUser from './authorizeUser.test';
 import './commentValidation.test';
+import * as createCategoryValidation from './createCategoryValidation.test';
 
 export default {
   verifyToken,
@@ -12,5 +13,6 @@ export default {
   profileValidation,
   checkUserVerification,
   paginationValidation,
-  authorizeUser
+  authorizeUser,
+  createCategoryValidation
 };

--- a/test/users/__mocks__/index.js
+++ b/test/users/__mocks__/index.js
@@ -67,9 +67,22 @@ const getComment = () => {
   return comment.valid;
 };
 
+/**
+ * @name sampleCategory
+ * @returns {Object} details of a user that wants to edit profile
+ */
+const sampleCategory = () => {
+  const sample = {
+    name: faker.commerce.department(),
+    description: faker.lorem.sentence()
+  };
+  return sample;
+};
+
 export {
   getNewUser,
   getNewUserWithProfile,
   getUserThatEditsProfile,
-  getComment
+  getComment,
+  sampleCategory
 };


### PR DESCRIPTION
#### What does this PR do?
Enables Admin and Superadmin user create categories

#### Description of Task proposed in this pull request?
- Update existing model with 'description' attribute
- Build the create category endpoint
- Write end to end test

#### How should this be manually tested (Quality Assurance)?
- Make a `POST` request to `/api/v1/categories/create`
- A `name` and `description` field is to be present in the request body.

#### What are the relevant pivotal tracker stories?
- Story ID:  [#167918277](https://www.pivotaltracker.com/story/show/167918277)

#### Any background context you want to add (Operations Impact)?
- Run `npm run db:rollback` to migrate all tables

#### What I have learned working on this feature: 
- I learnt how to validate fields

#### Screenshots: 
Create Category:
<img width="1440" alt="Screenshot 2019-08-15 at 12 25 46 PM" src="https://user-images.githubusercontent.com/47576037/63092037-45c3d500-bf58-11e9-9d9f-aaf95a90add4.png">

Resending the Same Request:
<img width="1440" alt="Screenshot 2019-08-15 at 12 25 53 PM" src="https://user-images.githubusercontent.com/47576037/63092054-4f4d3d00-bf58-11e9-9cf5-37e2c781e48d.png">


