### PR TITLE
#167917588 Authenticated User can Update and Delete Comments

### DIFF
--- a/server/controllers/Categories.js
+++ b/server/controllers/Categories.js
@@ -1,0 +1,42 @@
+import models from '../database/models';
+import { serverResponse, serverError } from '../helpers';
+
+const { Category } = models;
+
+/**
+ * @export
+ * @class Categories
+ */
+class Categories {
+  /**
+   * @name create
+   * @async
+   * @static
+   * @memberof Categories
+   * @param {Object} req express request object
+   * @param {Object} res express response object
+   * @returns {Json} server response
+   */
+  static async create(req, res) {
+    try {
+      const { description } = req.body;
+      const name = req.body.name.toLowerCase();
+      const existingCategory = await Category.findByName(name);
+      if (existingCategory) {
+        return serverResponse(res, 409, {
+          error: `${name} category already exists`
+        });
+      }
+      const newCategory = await Category.create({ name, description });
+
+      return serverResponse(res, 200, {
+        message: `${name} category successfully created`,
+        data: newCategory.dataValues
+      });
+    } catch (error) {
+      serverError(res);
+    }
+  }
+}
+
+export default Categories;

--- a/server/database/migrations/20190731135155-create-category.js
+++ b/server/database/migrations/20190731135155-create-category.js
@@ -10,6 +10,11 @@ export default {
       type: Sequelize.STRING,
       allowNull: false
     },
+    description: {
+      type: Sequelize.STRING(100),
+      allowNull: false,
+      defaultValue: ''
+    },
     createdAt: {
       allowNull: false,
       type: Sequelize.DATE

--- a/server/database/models/category.js
+++ b/server/database/models/category.js
@@ -6,6 +6,11 @@ export default (sequelize, DataTypes) => {
         allowNull: false,
         type: DataTypes.STRING,
         unique: true
+      },
+      description: {
+        allowNull: false,
+        type: DataTypes.STRING(100),
+        defaultValue: ''
       }
     },
     {}

--- a/server/database/seeds/20190730180408-my-seed-file.js
+++ b/server/database/seeds/20190730180408-my-seed-file.js
@@ -56,12 +56,14 @@ export default {
       },
       {
         firstName: 'demo',
-        lastName: 'user',
+        lastName: 'User',
         userName: 'demoUser',
         email: 'demoUser@gmail.com',
         password:
-            '$2y$12$3t1adkk7/grjsz2cG5hlXOTO8LwZUmGeG7zs6udoH78MeoPNmXQ.y',
-        bio: 'This is a simple bio of demo user',
+            '$2a$10$0dVjZKAHBb6Lg.dnujRwme1WbhMAfCIj02uptPxO.u5gNIi5DoqtW',
+        avatarUrl:
+            'https://res.cloudinary.com/teamrambo50/image/upload/v1565160704/avatar-1577909_1280_xsoxql.png',
+        bio: 'This is a simple bio of Escanor the sin of pride',
         role: 'superadmin',
         level: 5,
         followingsCount: 1,

--- a/server/docs/authors-haven-api.yml
+++ b/server/docs/authors-haven-api.yml
@@ -548,7 +548,6 @@ paths:
             application/json:
               schema:
                 "$ref": "#/components/schemas/serverResponse"                    
-          description: Internal server error
   /api/v1/articles/create:
     post:
       summary: A user can create an article
@@ -570,6 +569,8 @@ paths:
                 image:
                   type: string
                   format: binary
+                tags:
+                  type: string
       security:
         - ApiKeyAuth: []
       responses:
@@ -614,14 +615,12 @@ paths:
       responses:
         201:
           description: Comment Added
-
         404:
           description: Article not found
           content:
             application/json:
               schema:
                 "$ref": "#/components/schemas/errorResponse"
-
         422:
           description: comment validation error
           content:
@@ -634,9 +633,7 @@ paths:
           content:
             application/json:
               schema:
-                "$ref": "#/components/schemas/serverResponse"  
-
-    /api/v1/articles/{slug}/comments:
+                "$ref": "#/components/schemas/serverResponse"
     get:
       parameters:
         - in: path
@@ -661,7 +658,150 @@ paths:
           content:
             application/json:
               schema:
+                "$ref": "#/components/schemas/serverResponse"   
+
+  /api/v1/categories/create:
+    post:
+      summary: Logged In admin user can create a category
+      description: Create category
+      security:
+        - ApiKeyAuth: []
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/createCategory'
+      responses:
+        200:
+          description: category successfully created
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/createCategoryResponse"
+        401:
+          description: token expired
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        404:
+          description: user not found
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        409:
+          description: category already exists
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        500:
+          description: Server Error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/serverResponse"
+  
+  /api/v1/articles/{slug}/comments/{commentId}:
+    patch:
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+          description: Article Slug
+        - in: path
+          name: commentId
+          required: true
+          schema:
+            type: string
+          description: Comment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - comment
+              properties:
+                comment:
+                  type: text
+                  example: This is a comment. 
+      summary: Route to update comment of an article
+      description: Allows owner of a comment to update 
+      security:
+        - ApiKeyAuth: []
+      responses:
+        200:
+          description: comment updated successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/updateCommentResponse"
+        404:
+          description: article not found/no comments on article
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        500:
+          description: Internal server error  
+          content:
+            application/json:
+              schema:
                 "$ref": "#/components/schemas/serverResponse" 
+
+    /api/v1/articles/{slug}/comments/{commentId}:  
+    delete:
+        summary: Route to delete comment
+        description: Allows owner of a comment to delete comment 
+        security:
+          - ApiKeyAuth: []
+        parameters:
+          - in: path
+            name: slug
+            required: true
+            schema:
+              type: string
+            description: Article Slug
+          - in: path
+            name: commentId
+            required: true
+            schema:
+              type: string
+            description: Comment Id
+        responses:
+          200:
+            description: comment updated successfully
+            content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/updateCommentResponse"
+          401:
+          description: authentication error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+
+          404:
+            description: article not found/no comments on article
+            content:
+              application/json:
+                schema:
+                  "$ref": "#/components/schemas/errorResponse"
+          500:
+            description: Internal server error  
+            content:
+              application/json:
+                schema:
+                  "$ref": "#/components/schemas/serverResponse" 
+
+
 
                      
 components:
@@ -1024,13 +1164,31 @@ components:
             status:
               type: string
               example: status is required
-          
-          
-      
-
-        
-
-
-
-
-
+    createCategory:
+      type: object
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          example: newCategoryy
+    createCategoryResponse:
+      type: object
+      properties:
+        message:
+          type: string
+          example: newCategoryy category successfully created
+        data:
+          type: object
+          properties:
+            id: 
+              type: integer
+              example: 3
+            name:
+              type: string
+              example: newCategoryy
+    updateCommentResponse:
+      type: object
+      properties:
+        message:
+          type: string

--- a/server/middlewares/createCategoryValidation.js
+++ b/server/middlewares/createCategoryValidation.js
@@ -1,0 +1,21 @@
+import Joi from '@hapi/joi';
+import { category } from '../schemas';
+import { validateInputs } from '../helpers';
+
+/**
+ * Validates user inputs when he/she edit his/her profile
+ *
+ * @param {Object} req - ExpressJs request object
+ * @param {Object} res - ExpressJs response object
+ * @param {Function} next - ExpressJs next function
+ * @returns {(JSON|Function)} HTTP JSON response or ExpressJs next function
+ */
+const validateProfileEdit = (req, res, next) => {
+  const options = {
+    abortEarly: false
+  };
+
+  Joi.validate(req.body, category, options, validateInputs(res, next));
+};
+
+export default validateProfileEdit;

--- a/server/middlewares/index.js
+++ b/server/middlewares/index.js
@@ -9,6 +9,7 @@ import validatePagination from './paginationValidation';
 import validateArticle from './articleValidation';
 import authorizeUser from './authorizeUser';
 import validateCommentBody from './commentValidation';
+import createCategoryValidation from './createCategoryValidation';
 
 const middlewares = {
   verifyToken,
@@ -22,7 +23,8 @@ const middlewares = {
   validateResetPassword,
   validatePagination,
   authorizeUser,
-  validateCommentBody
+  validateCommentBody,
+  createCategoryValidation
 };
 
 export default middlewares;

--- a/server/routes/category.js
+++ b/server/routes/category.js
@@ -1,0 +1,22 @@
+import express from 'express';
+import Categories from '../controllers/Categories';
+import middlewares from '../middlewares';
+
+const route = express.Router();
+const {
+  authorizeUser,
+  verifyToken,
+  createCategoryValidation,
+  getSessionFromToken
+} = middlewares;
+
+route.post(
+  '/create',
+  verifyToken,
+  getSessionFromToken,
+  authorizeUser(4),
+  createCategoryValidation,
+  Categories.create
+);
+
+export default route;

--- a/server/routes/comment.js
+++ b/server/routes/comment.js
@@ -20,6 +20,23 @@ route.post(
   Comments.create
 );
 
+route.patch(
+  '/:slug/comments/:id',
+  verifyToken,
+  getSessionFromToken,
+  checkUserVerification,
+  validateCommentBody,
+  Comments.update
+);
+
+route.delete(
+  '/:slug/comments/:id',
+  verifyToken,
+  getSessionFromToken,
+  checkUserVerification,
+  Comments.delete
+);
+
 route.get('/:slug/comments', Comments.getArticleComments);
 
 export default route;

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -8,6 +8,7 @@ import profile from './profile';
 import article from './article';
 import tag from './tag';
 import comment from './comment';
+import category from './category';
 
 const route = express.Router();
 
@@ -18,7 +19,7 @@ route.use('/profiles', profile, follower);
 route.use('/user', userFollower);
 route.use('/articles', article);
 route.use('/tags', tag);
-route.use('/articles', comment);
 route.use('/articles', article, comment);
+route.use('/categories', category);
 
 export default route;

--- a/server/schemas/category.js
+++ b/server/schemas/category.js
@@ -1,0 +1,17 @@
+import Joi from '@hapi/joi';
+import { setCustomMessage } from '../helpers';
+
+export default {
+  name: Joi.string()
+    .required()
+    .min(2)
+    .max(20)
+    .regex(/\w/)
+    .error(setCustomMessage('category name')),
+  description: Joi.string()
+    .optional()
+    .min(2)
+    .max(100)
+    .regex(/\w/)
+    .error(setCustomMessage('category description'))
+};

--- a/server/schemas/index.js
+++ b/server/schemas/index.js
@@ -3,7 +3,13 @@ import profileEdit from './profileEdit';
 import paginationSchema from './pagination';
 import article from './article';
 import comment from './comment';
+import category from './category';
 
 export {
-  userSignup, profileEdit, article, paginationSchema, comment
+  userSignup,
+  profileEdit,
+  category,
+  article,
+  paginationSchema,
+  comment
 };

--- a/test/articles/__mocks__/index.js
+++ b/test/articles/__mocks__/index.js
@@ -33,6 +33,13 @@ const ArticleData2 = {
   tags: 'tech,business'
 };
 
+const ArticleData20 = {
+  title: ' is simply dummy text of the printing and typesetting ',
+  description: 'ext ever since the 1500s, when an unknown printer',
+  articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
+  status: 'publish'
+};
+
 const noTagArticleData = {
   title: ' is simply dummy text of the printing and typesetting ',
   description: 'ext ever since the 1500s, when an unknown printer',
@@ -104,5 +111,6 @@ export {
   invalidArticleData,
   ArticleData4,
   badImage,
-  ArticleData10
+  ArticleData10,
+  ArticleData20
 };

--- a/test/categories/createCategory.test.js
+++ b/test/categories/createCategory.test.js
@@ -1,0 +1,77 @@
+/* eslint-disable max-len */
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import app from '../../server';
+import Categories from '../../server/controllers/Categories';
+
+chai.use(chaiHttp);
+
+const { BASE_URL } = process.env;
+const { create } = Categories;
+
+let data;
+before(async () => {
+  const response = await chai
+    .request(app)
+    .post(`${BASE_URL}/sessions/create`)
+    .send({
+      userLogin: 'demoUser',
+      password: 'incorrect'
+    });
+  data = response.body;
+});
+
+describe('Create Categories Test', () => {
+  context('when a new category name is present', () => {
+    it('creates a new category', async () => {
+      const response = await chai
+        .request(app)
+        .post(`${BASE_URL}/categories/create`)
+        .set('Authorization', data.token)
+        .send({
+          name: 'demographically',
+          description: 'demograph of the world'
+        });
+      expect(response).to.have.status(200);
+      expect(response.body).to.have.key('message', 'data');
+      expect(response.body.data.name).to.equal('demographically');
+      expect(response.body.data.description).to.be.a('string');
+    });
+  });
+
+  context('when an existing category name is supplied', () => {
+    it('throws an error', async () => {
+      const response = await chai
+        .request(app)
+        .post(`${BASE_URL}/categories/create`)
+        .set('Authorization', data.token)
+        .send({
+          name: 'demographically',
+          description: 'demograph of the world'
+        });
+      expect(response).to.have.status(409);
+      expect(response.body).to.have.key('error');
+      expect(response.body.error).to.equal(
+        'demographically category already exists'
+      );
+    });
+  });
+
+  context('when the create method encounters a internal error', () => {
+    it('throws a server error', async () => {
+      const stubfunc = { create };
+      const sandbox = sinon.createSandbox();
+      sandbox.stub(stubfunc, 'create').rejects(new Error('Server Error'));
+
+      const next = sinon.spy();
+      const res = {
+        status: () => ({
+          json: next
+        })
+      };
+      await create({}, res);
+      sinon.assert.calledOnce(next);
+    });
+  });
+});

--- a/test/categories/index.js
+++ b/test/categories/index.js
@@ -1,0 +1,3 @@
+import * as createCategory from './createCategory.test';
+
+export default createCategory;

--- a/test/comments/index.js
+++ b/test/comments/index.js
@@ -1,1 +1,2 @@
 import './comment.test';
+import './updateComment.test';

--- a/test/comments/updateComment.test.js
+++ b/test/comments/updateComment.test.js
@@ -1,0 +1,282 @@
+/* eslint-disable no-unused-expressions */
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import { getNewUser } from '../users/__mocks__';
+import userData from '../users/__mocks__/user';
+import app from '../../server';
+import models from '../../server/database/models';
+import { ArticleData20 } from '../articles/__mocks__';
+
+const { Article } = models;
+const { rightUserWithEmail } = userData;
+
+chai.use(chaiHttp);
+
+let author;
+let artilceSlug;
+let commenter;
+let commenter2;
+let firstCommentId;
+
+const baseUrl = process.env.BASE_URL;
+
+before(async () => {
+  const user = getNewUser();
+  const signUpResponse = await chai
+    .request(app)
+    .post(`${baseUrl}/users/create`)
+    .send({
+      ...user,
+      confirmPassword: user.password
+    });
+  commenter = signUpResponse.body;
+
+  const user2 = getNewUser();
+  const signUpResponse2 = await chai
+    .request(app)
+    .post(`${baseUrl}/users/create`)
+    .send({
+      ...user2,
+      confirmPassword: user2.password
+    });
+  commenter2 = signUpResponse2.body;
+
+  const loginResponse = await chai
+    .request(app)
+    .post(`${baseUrl}/sessions/create`)
+    .send(rightUserWithEmail);
+  author = loginResponse.body;
+
+  const articleResponse = await chai
+    .request(app)
+    .post(`${baseUrl}/articles/create`)
+    .set('Authorization', author.token)
+    .send(ArticleData20);
+  artilceSlug = articleResponse.body.slug;
+
+  const res = await chai
+    .request(app)
+    .post(`${baseUrl}/articles/${artilceSlug}/comments`)
+    .set('authorization', commenter.token)
+    .send({
+      comment: new Array(4999).join('a')
+    });
+  firstCommentId = res.body.comment.id;
+});
+
+describe('Update comment test', async () => {
+  context(
+    'When an authenticated user updates comment with characters above required',
+    () => {
+      it('returns validation error', async () => {
+        const res = await chai
+          .request(app)
+          .patch(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(5555).join('a')
+          });
+        expect(res).to.have.status(422);
+        expect(res.body).to.haveOwnProperty('errors');
+        expect(res.body.errors).to.haveOwnProperty('comment');
+        expect(res.body.errors.comment).to.deep.equal(
+          'comment should not be more than 5000 characters'
+        );
+      });
+    }
+  );
+
+  context('When updating with comment id that is unavailable', () => {
+    it('returns error that comment does not exist', async () => {
+      const res = await chai
+        .request(app)
+        .patch(`${baseUrl}/articles/${artilceSlug}/comments/1000`)
+        .set('authorization', commenter.token)
+        .send({
+          comment: new Array(23).join('a')
+        });
+      expect(res).to.have.status(404);
+      expect(res.body).to.haveOwnProperty('error');
+      expect(res.body.error).to.deep.equal('comment not found');
+    });
+  });
+
+  context(
+    'When another authenticated user attempts to update another users comment',
+    () => {
+      it('returns error that comment does not exist', async () => {
+        const res = await chai
+          .request(app)
+          .patch(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter2.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(404);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal('comment not found');
+      });
+    }
+  );
+
+  context(
+    'When authenticated user successfully updates his/her comment',
+    () => {
+      it('returns success message with the new comment details', async () => {
+        const res = await chai
+          .request(app)
+          .patch(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(200);
+        expect(res.body).to.haveOwnProperty('message');
+        expect(res.body.message).to.deep.equal('comment updated');
+        expect(res.body).to.haveOwnProperty('comment');
+        expect(res.body.comment).to.be.an('object');
+      });
+    }
+  );
+
+  context('When there is server error while updating a comment', () => {
+    it('returns a 500 error', async () => {
+      const stub = sinon.stub(Article, 'findBySlug');
+      const error = new Error('server error, this will be resolved shortly');
+      stub.yields(error);
+
+      const res = await chai
+        .request(app)
+        .patch(`${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`)
+        .set('authorization', commenter.token)
+        .send({
+          comment: new Array(3000).join('a')
+        });
+      expect(res).to.have.status(500);
+      expect(res.body).to.include.key('error');
+      expect(res.body.error).to.equal(
+        'server error, this will be resolved shortly'
+      );
+      stub.restore();
+    });
+  });
+
+  context(
+    'When user attempts updating comment with unavailabe article slug',
+    () => {
+      it('returns error that article does not exist', async () => {
+        const res = await chai
+          .request(app)
+          .patch(`${baseUrl}/articles/artilceSlug/comments/${firstCommentId}`)
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(404);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal('article not found');
+      });
+    }
+  );
+});
+
+describe('Delete Comment test', async () => {
+  context('When deleting with comment id that is unavailable', () => {
+    it('returns error that comment does not exist', async () => {
+      const res = await chai
+        .request(app)
+        .delete(`${baseUrl}/articles/${artilceSlug}/comments/1000`)
+        .set('authorization', commenter.token);
+      expect(res).to.have.status(404);
+      expect(res.body).to.haveOwnProperty('error');
+      expect(res.body.error).to.deep.equal('comment not found');
+    });
+  });
+
+  context(
+    'When another authenticated user attempts to delete another users comment',
+    () => {
+      it('returns error that comment does not exist', async () => {
+        const res = await chai
+          .request(app)
+          .delete(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter2.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(404);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal('comment not found');
+      });
+    }
+  );
+
+  context('When there is server error while deleting a comment', () => {
+    it('returns a 500 error', async () => {
+      const stub = sinon.stub(Article, 'findBySlug');
+      const error = new Error('server error, this will be resolved shortly');
+      stub.yields(error);
+
+      const res = await chai
+        .request(app)
+        .delete(`${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`)
+        .set('authorization', commenter.token)
+        .send({
+          comment: new Array(3000).join('a')
+        });
+      expect(res).to.have.status(500);
+      expect(res.body).to.include.key('error');
+      expect(res.body.error).to.equal(
+        'server error, this will be resolved shortly'
+      );
+      stub.restore();
+    });
+  });
+
+  context(
+    'When user attempts deleting comment with unavailabe article slug',
+    () => {
+      it('returns error that article does not exist', async () => {
+        const res = await chai
+          .request(app)
+          .delete(`${baseUrl}/articles/artilceSlug/comments/${firstCommentId}`)
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(404);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal('article not found');
+      });
+    }
+  );
+
+  context(
+    'When authenticated user successfully deletes his/her comment',
+    () => {
+      it('returns success message', async () => {
+        const res = await chai
+          .request(app)
+          .delete(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(200);
+        expect(res.body).to.haveOwnProperty('message');
+        expect(res.body.message).to.deep.equal('comment deleted');
+      });
+    }
+  );
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -11,6 +11,7 @@ import './profiles';
 import './articles';
 import './tags';
 import './comments';
+import './categories';
 
 const { expect } = chai;
 chai.use(chaiHttp);

--- a/test/middlewares/createCategoryValidation.test.js
+++ b/test/middlewares/createCategoryValidation.test.js
@@ -1,0 +1,109 @@
+/* eslint-disable max-len */
+import chai from 'chai';
+import sinon from 'sinon';
+import validateProfileEdit from '../../server/middlewares/createCategoryValidation';
+import { sampleCategory } from '../users/__mocks__';
+
+const { expect } = chai;
+
+const next = sinon.stub();
+const req = {};
+const res = {
+  body: null,
+  statusCode: null,
+  send(data) {
+    this.body = data;
+    return data;
+  },
+  json(data) {
+    this.body = data;
+    return data;
+  },
+  status(responseStatus) {
+    this.statusCode = responseStatus;
+    return this;
+  }
+};
+
+describe('Create Category Validation Middleware', () => {
+  const validCategory = sampleCategory();
+
+  context('when the name is not given', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      delete invalidCategory.name;
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('name');
+      expect(res.body.errors.name).to.match(/category name is required/i);
+    });
+  });
+
+  context('when the name is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.name = '///';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('name');
+      expect(res.body.errors.name).to.match(/category name is invalid/i);
+    });
+  });
+
+  context('when the description is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.description = '///';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('description');
+      expect(res.body.errors.description).to.match(
+        /category description is invalid/i
+      );
+    });
+  });
+
+  context('when the name is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.name = '';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('name');
+      expect(res.body.errors.name).to.match(/category name is invalid/i);
+    });
+  });
+
+  context('when the description is invalid', () => {
+    it('returns a status code 422 and an error message', () => {
+      const invalidCategory = { ...validCategory };
+      invalidCategory.description = '';
+
+      req.body = invalidCategory;
+      validateProfileEdit(req, res, next);
+
+      expect(res.statusCode).to.equal(422);
+      expect(res.body).to.haveOwnProperty('errors');
+      expect(res.body.errors).to.haveOwnProperty('description');
+      expect(res.body.errors.description).to.match(
+        /category description is invalid/i
+      );
+    });
+  });
+});

--- a/test/middlewares/index.js
+++ b/test/middlewares/index.js
@@ -5,6 +5,7 @@ import * as checkUserVerification from './checkUserVerification.test';
 import * as paginationValidation from './paginationValidation.test';
 import * as authorizeUser from './authorizeUser.test';
 import './commentValidation.test';
+import * as createCategoryValidation from './createCategoryValidation.test';
 
 export default {
   verifyToken,
@@ -12,5 +13,6 @@ export default {
   profileValidation,
   checkUserVerification,
   paginationValidation,
-  authorizeUser
+  authorizeUser,
+  createCategoryValidation
 };

--- a/test/users/__mocks__/index.js
+++ b/test/users/__mocks__/index.js
@@ -67,9 +67,22 @@ const getComment = () => {
   return comment.valid;
 };
 
+/**
+ * @name sampleCategory
+ * @returns {Object} details of a user that wants to edit profile
+ */
+const sampleCategory = () => {
+  const sample = {
+    name: faker.commerce.department(),
+    description: faker.lorem.sentence()
+  };
+  return sample;
+};
+
 export {
   getNewUser,
   getNewUserWithProfile,
   getUserThatEditsProfile,
-  getComment
+  getComment,
+  sampleCategory
 };


### PR DESCRIPTION
#### What does this PR do?
- Add route for comment owner to update his/her comment
- Add route for comment owner to delete his/her a comment
- Add validation to update comment
- Add tests


#### Description of Task proposed in this pull request?
- Add route to update comment - PATCH  /articles/< slug >/comments/< commentId > [Protected Route]
- Add route to delete comment - DELETE  /articles/< slug >/comments/< commentId >  [Protected Route]
- Add comment validation
- Document feature on swagger

#### How should this be manually tested (Quality Assurance)?
- Checkout to this branch ft-user-update-delete-comment-167917588.
- Register or login to get an authentication token.
- Comment on any article
- Use the update comment route to update the comment. Required: comment: "Insert comment".
- Use the delete comment route to delete the comment.

#### What are the relevant pivotal tracker stories?
- [#167917588](https://www.pivotaltracker.com/story/show/167917588)

#### What I have learned working on this feature: 
- I learnt Sequelize association

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
