### PR TITLE
#167917588 Authenticated User can Update and Delete Comments

### DIFF
--- a/server/docs/authors-haven-api.yml
+++ b/server/docs/authors-haven-api.yml
@@ -868,6 +868,103 @@ paths:
             schema:
               '$ref': '#/components/schemas/serverResponse'
 
+  /api/v1/articles/{slug}/comments/{commentId}:
+    patch:
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+          description: Article Slug
+        - in: path
+          name: commentId
+          required: true
+          schema:
+            type: integer
+          description: Comment Id
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required:
+              - comment
+              properties:
+                comment:
+                  type: text
+                  example: This is a comment. 
+      summary: Route to update comment of an article
+      description: Allows owner of a comment to update 
+      security:
+        - ApiKeyAuth: []
+      responses:
+        200:
+          description: comment updated successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/updateCommentResponse"
+        404:
+          description: article not found/no comments on article
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        500:
+          description: Internal server error  
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/serverResponse"  
+                
+    delete:
+      summary: Route to delete comment
+      description: Allows owner of a comment to delete comment 
+      security:
+        - ApiKeyAuth: []
+      parameters:
+        - in: path
+          name: slug
+          required: true
+          schema:
+            type: string
+          description: Article Slug
+        - in: path
+          name: commentId
+          required: true
+          schema:
+            type: integer
+          description: Comment Id
+      responses:
+        200:
+          description: comment deleted successfully
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/updateCommentResponse"
+        401:
+          description: authentication error
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+
+        404:
+          description: article not found/no comments for article
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/errorResponse"
+        500:
+          description: Internal server error  
+          content:
+            application/json:
+              schema:
+                "$ref": "#/components/schemas/serverResponse" 
+      
+                     
 components:
   securitySchemes:
     BearerAuth:
@@ -1329,3 +1426,9 @@ components:
                     type: string
                     format: date-time
                     example: 2017-07-21T17:32:28Z
+    updateCommentResponse:
+      type: object
+      properties:
+        message:
+          type: string 
+         

--- a/server/routes/comment.js
+++ b/server/routes/comment.js
@@ -13,11 +13,28 @@ const {
 
 route.post(
   '/:slug/comments',
+  validateCommentBody,
   verifyToken,
   getSessionFromToken,
   checkUserVerification,
-  validateCommentBody,
   Comments.create
+);
+
+route.patch(
+  '/:slug/comments/:id',
+  validateCommentBody,
+  verifyToken,
+  getSessionFromToken,
+  checkUserVerification,
+  Comments.update
+);
+
+route.delete(
+  '/:slug/comments/:id',
+  verifyToken,
+  getSessionFromToken,
+  checkUserVerification,
+  Comments.delete
 );
 
 route.get('/:slug/comments', Comments.getArticleComments);

--- a/server/routes/index.js
+++ b/server/routes/index.js
@@ -17,9 +17,8 @@ route.use('/sessions', session);
 route.use('/auth', auth);
 route.use('/profiles', profile, follower);
 route.use('/user', userFollower);
-route.use('/articles', article);
-route.use('/tags', tag);
 route.use('/articles', article, comment);
+route.use('/tags', tag);
 route.use('/categories', category);
 
 export default route;

--- a/test/articles/__mocks__/index.js
+++ b/test/articles/__mocks__/index.js
@@ -33,6 +33,13 @@ const ArticleData2 = {
   tags: 'tech,business'
 };
 
+const ArticleData20 = {
+  title: ' is simply dummy text of the printing and typesetting ',
+  description: 'ext ever since the 1500s, when an unknown printer',
+  articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
+  status: 'publish'
+};
+
 const noTagArticleData = {
   title: ' is simply dummy text of the printing and typesetting ',
   description: 'ext ever since the 1500s, when an unknown printer',
@@ -114,5 +121,6 @@ export {
   ArticleData4,
   badImage,
   ArticleData10,
+  ArticleData20,
   authenticatedUser
 };

--- a/test/comments/comment.test.js
+++ b/test/comments/comment.test.js
@@ -109,7 +109,7 @@ describe('Add Comments to Article Tests', async () => {
   context(
     `
   when authenticated user attempts submitting number 
-  of chars above required`,
+  of chars above 5000`,
     () => {
       it('returns error', async () => {
         const res = await chai

--- a/test/comments/index.js
+++ b/test/comments/index.js
@@ -1,1 +1,2 @@
 import './comment.test';
+import './updateComment.test';

--- a/test/comments/updateComment.test.js
+++ b/test/comments/updateComment.test.js
@@ -1,0 +1,286 @@
+/* eslint-disable no-unused-expressions */
+import chai, { expect } from 'chai';
+import chaiHttp from 'chai-http';
+import sinon from 'sinon';
+import { getNewUser } from '../users/__mocks__';
+import userData from '../users/__mocks__/user';
+import app from '../../server';
+import models from '../../server/database/models';
+import { ArticleData20 } from '../articles/__mocks__';
+
+const { Article } = models;
+const { rightUserWithEmail } = userData;
+
+chai.use(chaiHttp);
+
+let author;
+let artilceSlug;
+let commenter;
+let commenter2;
+let firstCommentId;
+
+const baseUrl = process.env.BASE_URL;
+
+before(async () => {
+  const user = getNewUser();
+  const signUpResponse = await chai
+    .request(app)
+    .post(`${baseUrl}/users/create`)
+    .send({
+      ...user,
+      confirmPassword: user.password
+    });
+  commenter = signUpResponse.body;
+
+  const user2 = getNewUser();
+  const signUpResponse2 = await chai
+    .request(app)
+    .post(`${baseUrl}/users/create`)
+    .send({
+      ...user2,
+      confirmPassword: user2.password
+    });
+  commenter2 = signUpResponse2.body;
+
+  const loginResponse = await chai
+    .request(app)
+    .post(`${baseUrl}/sessions/create`)
+    .send(rightUserWithEmail);
+  author = loginResponse.body;
+
+  const articleResponse = await chai
+    .request(app)
+    .post(`${baseUrl}/articles/create`)
+    .set('Authorization', author.token)
+    .send(ArticleData20);
+  artilceSlug = articleResponse.body.slug;
+
+  const res = await chai
+    .request(app)
+    .post(`${baseUrl}/articles/${artilceSlug}/comments`)
+    .set('authorization', commenter.token)
+    .send({
+      comment: new Array(4999).join('a')
+    });
+  firstCommentId = res.body.comment.id;
+});
+
+describe('Update comment test', async () => {
+  context(
+    'When an authenticated user updates comment with characters above 5000',
+    () => {
+      it('returns validation error', async () => {
+        const res = await chai
+          .request(app)
+          .patch(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(5555).join('a')
+          });
+        expect(res).to.have.status(422);
+        expect(res.body).to.haveOwnProperty('errors');
+        expect(res.body.errors).to.haveOwnProperty('comment');
+        expect(res.body.errors.comment).to.deep.equal(
+          'comment should not be more than 5000 characters'
+        );
+      });
+    }
+  );
+
+  context('When updating with comment id that is unavailable', () => {
+    it('returns error that comment does not exist', async () => {
+      const res = await chai
+        .request(app)
+        .patch(`${baseUrl}/articles/${artilceSlug}/comments/1000`)
+        .set('authorization', commenter.token)
+        .send({
+          comment: new Array(23).join('a')
+        });
+      expect(res).to.have.status(404);
+      expect(res.body).to.haveOwnProperty('error');
+      expect(res.body.error).to.deep.equal('comment not found');
+    });
+  });
+
+  context(
+    "When another authenticated user attempts to update another user's comment",
+    () => {
+      it('returns a permission error', async () => {
+        const res = await chai
+          .request(app)
+          .patch(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter2.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(403);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal(
+          "you don't have permission to access this content"
+        );
+      });
+    }
+  );
+
+  context(
+    'When authenticated user successfully updates his/her comment',
+    () => {
+      it('returns success message with the new comment details', async () => {
+        const res = await chai
+          .request(app)
+          .patch(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(200);
+        expect(res.body).to.haveOwnProperty('message');
+        expect(res.body.message).to.deep.equal('comment updated');
+        expect(res.body).to.haveOwnProperty('comment');
+        expect(res.body.comment).to.be.an('object');
+      });
+    }
+  );
+
+  context('When there is server error while updating a comment', () => {
+    it('returns a 500 error', async () => {
+      const stub = sinon.stub(Article, 'findBySlug');
+      const error = new Error('server error, this will be resolved shortly');
+      stub.yields(error);
+
+      const res = await chai
+        .request(app)
+        .patch(`${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`)
+        .set('authorization', commenter.token)
+        .send({
+          comment: new Array(3000).join('a')
+        });
+      expect(res).to.have.status(500);
+      expect(res.body).to.include.key('error');
+      expect(res.body.error).to.equal(
+        'server error, this will be resolved shortly'
+      );
+      stub.restore();
+    });
+  });
+
+  context(
+    'When user attempts updating comment with unavailabe article slug',
+    () => {
+      it('returns error that article does not exist', async () => {
+        const res = await chai
+          .request(app)
+          .patch(`${baseUrl}/articles/artilceSlug/comments/${firstCommentId}`)
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(404);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal('article not found');
+      });
+    }
+  );
+});
+
+describe('Delete Comment test', async () => {
+  context('When deleting with comment id that is unavailable', () => {
+    it('returns error that comment does not exist', async () => {
+      const res = await chai
+        .request(app)
+        .delete(`${baseUrl}/articles/${artilceSlug}/comments/1000`)
+        .set('authorization', commenter.token);
+      expect(res).to.have.status(404);
+      expect(res.body).to.haveOwnProperty('error');
+      expect(res.body.error).to.deep.equal('comment not found');
+    });
+  });
+
+  context(
+    "When another authenticated user attempts to delete another user's comment",
+    () => {
+      it('returns a permission error', async () => {
+        const res = await chai
+          .request(app)
+          .delete(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter2.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(403);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal(
+          "you don't have permission to access this content"
+        );
+      });
+    }
+  );
+
+  context('When there is server error while deleting a comment', () => {
+    it('returns a 500 error', async () => {
+      const stub = sinon.stub(Article, 'findBySlug');
+      const error = new Error('server error, this will be resolved shortly');
+      stub.yields(error);
+
+      const res = await chai
+        .request(app)
+        .delete(`${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`)
+        .set('authorization', commenter.token)
+        .send({
+          comment: new Array(3000).join('a')
+        });
+      expect(res).to.have.status(500);
+      expect(res.body).to.include.key('error');
+      expect(res.body.error).to.equal(
+        'server error, this will be resolved shortly'
+      );
+      stub.restore();
+    });
+  });
+
+  context(
+    'When user attempts deleting comment with unavailabe article slug',
+    () => {
+      it('returns error that article does not exist', async () => {
+        const res = await chai
+          .request(app)
+          .delete(`${baseUrl}/articles/artilceSlug/comments/${firstCommentId}`)
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(404);
+        expect(res.body).to.haveOwnProperty('error');
+        expect(res.body.error).to.deep.equal('article not found');
+      });
+    }
+  );
+
+  context(
+    'When authenticated user successfully deletes his/her comment',
+    () => {
+      it('returns success message', async () => {
+        const res = await chai
+          .request(app)
+          .delete(
+            `${baseUrl}/articles/${artilceSlug}/comments/${firstCommentId}`
+          )
+          .set('authorization', commenter.token)
+          .send({
+            comment: new Array(23).join('a')
+          });
+        expect(res).to.have.status(200);
+        expect(res.body).to.haveOwnProperty('message');
+        expect(res.body.message).to.deep.equal('comment deleted');
+      });
+    }
+  );
+});


### PR DESCRIPTION
#### What does this PR do?
- Add route for comment owner to update his/her comment
- Add route for comment owner to delete his/her a comment
- Add validation to update comment
- Add tests


#### Description of Task proposed in this pull request?
- Add route to update comment - PATCH  /articles/< slug >/comments/< commentId > [Protected Route]
- Add route to delete comment - DELETE  /articles/< slug >/comments/< commentId >  [Protected Route]
- Add comment validation
- Document feature on swagger

#### How should this be manually tested (Quality Assurance)?
- Checkout to this branch ft-user-can-update-delete-comment-167917588
- Register or login to get an authentication token
- Create an article and comment on it
- Use the update comment route to update the comment. **Required Field**:  ``` comment: "update your comment".```
- Use the delete comment route to delete the comment.

#### What are the relevant pivotal tracker stories?
- [#167917588](https://www.pivotaltracker.com/story/show/167917588)

#### What I have learned working on this feature: 
- I learnt Sequelize association

#### Screenshots: [If you made some visual changes to the application please upload screenshots here, or remove this section]
