### PR TITLE
 #167969545 Add Category On Article Creation

### DIFF
--- a/server/database/migrations/20190813135136-create-article.js
+++ b/server/database/migrations/20190813135136-create-article.js
@@ -1,3 +1,5 @@
+import { userInfo } from 'os';
+
 export default {
   up: (queryInterface, Sequelize) => queryInterface.createTable('Articles', {
     id: {
@@ -22,7 +24,18 @@ export default {
       type: Sequelize.TEXT
     },
     authorId: {
-      type: Sequelize.INTEGER
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Users',
+        key: 'id'
+      }
+    },
+    categoryId: {
+      type: Sequelize.INTEGER,
+      references: {
+        model: 'Categories',
+        key: 'id'
+      }
     },
     likesCount: {
       type: Sequelize.INTEGER

--- a/server/database/migrations/20190813135136-create-article.js
+++ b/server/database/migrations/20190813135136-create-article.js
@@ -1,5 +1,3 @@
-import { userInfo } from 'os';
-
 export default {
   up: (queryInterface, Sequelize) => queryInterface.createTable('Articles', {
     id: {

--- a/server/database/models/article.js
+++ b/server/database/models/article.js
@@ -37,6 +37,14 @@ export default (sequelize, DataTypes) => {
         type: DataTypes.TEXT,
         allowNull: true
       },
+      authorId: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      },
+      categoryId: {
+        type: DataTypes.INTEGER,
+        allowNull: false
+      },
       likesCount: {
         type: DataTypes.INTEGER,
         defaultValue: 0,
@@ -118,6 +126,11 @@ export default (sequelize, DataTypes) => {
       scope: {
         contentType: 'article'
       }
+    });
+    Article.belongsTo(models.Category, {
+      foreignKey: 'categoryId',
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
     });
   };
 

--- a/server/database/models/category.js
+++ b/server/database/models/category.js
@@ -29,6 +29,11 @@ export default (sequelize, DataTypes) => {
       through: 'UserCategory',
       as: 'users'
     });
+    Category.hasMany(models.Article, {
+      foreignKey: 'categoryId',
+      onUpdate: 'CASCADE',
+      onDelete: 'CASCADE'
+    });
   };
   return Category;
 };

--- a/server/database/seeds/20190731140728-categories-list.js
+++ b/server/database/seeds/20190731140728-categories-list.js
@@ -3,6 +3,11 @@ export default {
     'Categories',
     [
       {
+        name: 'other',
+        createdAt: new Date(),
+        updatedAt: new Date()
+      },
+      {
         name: 'Arts & Entertainment',
         createdAt: new Date(),
         updatedAt: new Date()

--- a/server/database/seeds/20190731140728-categories-list.js
+++ b/server/database/seeds/20190731140728-categories-list.js
@@ -8,27 +8,27 @@ export default {
         updatedAt: new Date()
       },
       {
-        name: 'Arts & Entertainment',
+        name: 'arts & entertainment',
         createdAt: new Date(),
         updatedAt: new Date()
       },
       {
-        name: 'Industry',
+        name: 'industry',
         createdAt: new Date(),
         updatedAt: new Date()
       },
       {
-        name: 'Innovation & Tech',
+        name: 'innovation & tech',
         createdAt: new Date(),
         updatedAt: new Date()
       },
       {
-        name: 'Life',
+        name: 'life',
         createdAt: new Date(),
         updatedAt: new Date()
       },
       {
-        name: 'Society',
+        name: 'society',
         createdAt: new Date(),
         updatedAt: new Date()
       }

--- a/server/docs/authors-haven-api.yml
+++ b/server/docs/authors-haven-api.yml
@@ -571,6 +571,8 @@ paths:
                   format: binary
                 tags:
                   type: string
+                category:
+                  type: string
       security:
         - ApiKeyAuth: []
       responses:
@@ -1313,6 +1315,13 @@ components:
           type: string
           format: date-time
           example: title-1
+        category:
+          type: object
+          properties:
+            id:
+              type: integer
+            name:
+              type: string
     changeArticleErrorResponse:
       type: object
       properties:

--- a/server/schemas/article.js
+++ b/server/schemas/article.js
@@ -17,7 +17,7 @@ export default {
     .error(setCustomMessage('status', 'valid status')),
   articleBody: Joi.string()
     .min(2)
-    .error(setCustomMessage('articleBody')),
+    .error(setCustomMessage('article body')),
   avatarUrl: Joi.string()
     .uri()
     .error(setCustomMessage('image')),

--- a/server/schemas/article.js
+++ b/server/schemas/article.js
@@ -25,5 +25,9 @@ export default {
     .optional()
     .min(2)
     .max(250)
-    .error(setCustomMessage('tags'))
+    .error(setCustomMessage('tags')),
+  category: Joi.string()
+    .required()
+    .min(2)
+    .error(setCustomMessage('category'))
 };

--- a/test/articles/__mocks__/index.js
+++ b/test/articles/__mocks__/index.js
@@ -6,6 +6,8 @@ const ArticleData = {
   image: faker.internet.avatar(),
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
   status: 'publish',
+  authorId: 1,
+  categoryId: 1,
   tags: ['tech', 'business']
 };
 
@@ -22,7 +24,17 @@ const ArticleData4 = {
   description: 'ext ever since the 1500s, when an unknown printer',
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
   status: 'draft',
-  tags: 'tech,business'
+  tags: 'tech,business',
+  category: 'other'
+};
+
+const ArticleData5 = {
+  title: ' is simply dummy text of the printing and typesetting ',
+  description: 'ext ever since the 1500s, when an unknown printer',
+  articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
+  status: 'draft',
+  tags: 'tech,business',
+  category: 'Lifestyle'
 };
 
 const ArticleData2 = {
@@ -30,21 +42,25 @@ const ArticleData2 = {
   description: 'ext ever since the 1500s, when an unknown printer',
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
   status: 'publish',
-  tags: 'tech,business'
+  tags: 'tech,business',
+  category: 'sport'
 };
 
 const ArticleData20 = {
   title: ' is simply dummy text of the printing and typesetting ',
   description: 'ext ever since the 1500s, when an unknown printer',
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
-  status: 'publish'
+  status: 'publish',
+  tags: 'tech,business',
+  category: 'sport'
 };
 
 const noTagArticleData = {
   title: ' is simply dummy text of the printing and typesetting ',
   description: 'ext ever since the 1500s, when an unknown printer',
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
-  status: 'publish'
+  status: 'publish',
+  category: 'sport'
 };
 
 const newArticleData = {
@@ -52,13 +68,15 @@ const newArticleData = {
   description: 'ext ever since the 1500s, when an unknown printer',
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
   status: 'publish',
-  tags: 'technology'
+  tags: 'technology',
+  category: 'Life'
 };
 const ArticleData10 = {
   title: ' is simply dummy text of the printing and typesetting ',
   description: 'ext ever since the 1500s, when an unknown printer',
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
-  status: 'publish'
+  status: 'publish',
+  category: 'Life'
 };
 
 const myfile = faker.image.dataUri(200, 200);
@@ -75,7 +93,8 @@ const request = {
     title: ' is simply dummy text of the printing and typesetting ',
     description: 'ext ever since the 1500s, when an unknown printer',
     articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
-    tags: 'tech, business'
+    tags: 'tech, business',
+    category: 'sport'
   },
   user: { id: 1 }
 };
@@ -97,7 +116,13 @@ const badImage = {
   description: 'ext ever since the 1500s, when an unknown printer',
   articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
   image: 'this is TIA',
-  tags: 'tech,business'
+  tags: 'tech,business',
+  category: 'business'
+};
+
+const categoryDetails = {
+  name: '',
+  id: 1
 };
 
 const authenticatedUser = {
@@ -120,7 +145,9 @@ export {
   invalidArticleData,
   ArticleData4,
   badImage,
+  ArticleData5,
   ArticleData10,
   ArticleData20,
-  authenticatedUser
+  authenticatedUser,
+  categoryDetails
 };


### PR DESCRIPTION
#### What does this PR do?
This PR enables user to add category an article belongs to during article creation

#### Description of Task proposed in this pull request?
- articles controller 
- swagger docs
- article test

#### How should this be manually tested (Quality Assurance)?
```
npm run start:dev
localhost/api/v1/articles/create
{
"title": "hellobabye",
"category" : "Life",
"tags" : "friend,just"
}
```

#### What are the relevant pivotal tracker stories?
- [167969545](https://www.pivotaltracker.com/story/show/167969545)

#### Any background context you want to add (Operations Impact)?
- The endpoint for article creation is protected add the token in the header


#### What I have learned working on this feature
- I learnt how to further use sequelize association
- I learnt how to mock cloudinary API


#### Screenshots: 
<img width="911" alt="Screenshot 2019-08-19 at 4 41 59 PM" src="https://user-images.githubusercontent.com/44194416/63350224-ebaa8180-c354-11e9-899f-5b6aca0d882d.png">
