### PR TITLE
Fix Tag Limit And Spacing

### DIFF
--- a/server/controllers/Articles.js
+++ b/server/controllers/Articles.js
@@ -158,7 +158,8 @@ const createLikeOrDislike = async (userAction, userId, article) => {
       return {
         status: 400,
         message: {
-          error: 'each tag must be more than a character'
+          error:
+            'tags cannot be more than 15 and each tag must be more than a character'
         }
       };
     }

--- a/server/controllers/Tags.js
+++ b/server/controllers/Tags.js
@@ -44,7 +44,7 @@ class Tags {
   static async create(tagList) {
     if (!tagList || tagList.length < 1) return null;
     const tagArray = tagList.split(',');
-    if (tagArray.some(tag => tag.length < 2)) return false;
+    if (tagArray.some(tag => tag.length < 2) || tagArray.length > 15) return false;
     const plainTags = tagArray
       .map(eachTag => formatTag(eachTag))
       .filter(tag => tag !== '');

--- a/server/helpers/tagHelpers.js
+++ b/server/helpers/tagHelpers.js
@@ -12,14 +12,15 @@ const removeSpecialCharacters = name => name.replace(/[^a-z0-9]/gi, '').toLowerC
  */
 const formatTag = (name) => {
   let formattedName = name.replace(/[^a-z0-9\s]/gi, '-').toLowerCase();
-  while (/--|-\s+-/.test(formattedName) || /\s\s/.test(formattedName)) {
+  while (
+    /--+|-+\s+-+|\s+-+\s+/.test(formattedName)
+    || /\s\s+/.test(formattedName)
+  ) {
     formattedName = formattedName
-      .replace(/--|-\s+-/gi, '-')
-      .replace(/\s\s/gi, ' ')
-      .trimEnd()
-      .trimStart();
+      .replace(/--+|-+\s+-+|\s+-+\s+/gi, '-')
+      .replace(/\s\s+/gi, ' ');
   }
-  return formattedName === '-' ? '' : formattedName;
+  return formattedName === '-' ? '' : formattedName.trimEnd().trimStart();
 };
 
 /**

--- a/test/articles/__mocks__/index.js
+++ b/test/articles/__mocks__/index.js
@@ -46,6 +46,27 @@ const ArticleData2 = {
   category: 'sport'
 };
 
+const ArticleData3 = {
+  title: ' is simply dummy text of the printing and typesetting ',
+  description: 'ext ever since the 1500s, when an unknown printer',
+  articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
+  status: 'publish',
+  tags: ' technnnnn , businesssss  ',
+  category: 'sport'
+};
+
+const surplusTagArticleData = {
+  title: ' is simply dummy text of the printing and typesetting ',
+  description: 'ext ever since the 1500s, when an unknown printer',
+  articleBody: 'ext ever since the 1500s, when an unknown printer took a ga',
+  status: 'publish',
+  tags: Array(17)
+    .fill('-')
+    .map(item => faker.commerce.department())
+    .join(),
+  category: 'sport'
+};
+
 const ArticleData20 = {
   title: ' is simply dummy text of the printing and typesetting ',
   description: 'ext ever since the 1500s, when an unknown printer',
@@ -153,5 +174,7 @@ export {
   ArticleData10,
   ArticleData20,
   authenticatedUser,
-  categoryDetails
+  categoryDetails,
+  ArticleData3,
+  surplusTagArticleData
 };

--- a/test/articles/create.test.js
+++ b/test/articles/create.test.js
@@ -14,7 +14,9 @@ import {
   invalidArticleData,
   request,
   ArticleData5,
-  categoryDetails
+  categoryDetails,
+  ArticleData3,
+  surplusTagArticleData
 } from './__mocks__';
 
 chai.use(chaiHttp);
@@ -142,6 +144,37 @@ describe('Create Article Test', () => {
     });
   });
 
+  context('when a user submits an article with tags that has spaces', () => {
+    it('formats the spaces', async () => {
+      const response = await chai
+        .request(app)
+        .post(`${BASE_URL}/articles/create`)
+        .set('Authorization', userToken)
+        .send(ArticleData3);
+      expect(response.status).to.equal(200);
+      expect(response.body.tagList).to.be.an('array');
+      expect(response.body.tagList).to.have.members([
+        'technnnnn',
+        'businesssss',
+        'sport'
+      ]);
+    });
+  });
+
+  context('when a user submits an article with more than 15 tags', () => {
+    it('returns error', async () => {
+      const response = await chai
+        .request(app)
+        .post(`${BASE_URL}/articles/create`)
+        .set('Authorization', userToken)
+        .send(surplusTagArticleData);
+      expect(response).to.have.status(400);
+      expect(response.body.error).to.equal(
+        'tags cannot be more than 15 and each tag must be more than a character'
+      );
+    });
+  });
+
   context(
     'when a user enters a list of tags, with a tag thats just a letter',
     () => {
@@ -155,7 +188,7 @@ describe('Create Article Test', () => {
           .send(badArticleTag);
         expect(response).to.have.status(400);
         expect(response.body.error).to.equal(
-          'each tag must be more than a character'
+          'tags cannot be more than 15 and each tag must be more than a character'
         );
       });
     }


### PR DESCRIPTION
#### What does this PR do?
- Fix bug in tagging
#### Description of Task proposed in this pull request?
- Removes unwanted spaces in tag
- Limit amount of tags on an article
- Write test to ensure working functionality

#### How should this be manually tested (Quality Assurance)?
- Run `npm run db:rollback` to get all tables
- On the creation of the Article, you add tags(add spaces to the tags). 
Route `POST` `api/v1/article/create` `[Protected]`
body: 
{
"title": "Success In Life",
"status": "publish",
"articleBody": "Failure is the best Lecturer for a Success course",
"tags": " tech ,   motorbike  ",
"category":"sports"
}

#### What are the relevant pivotal tracker stories?
- N/A

#### Any background context you want to add (Operations Impact)?
- Run `npm run db:rollback` to get all tables

#### What I have learned working on this feature: 
- I learned how to compare the content of an array in a test

#### Screenshots: 
- Adding Tags with spaces
<img width="1680" alt="Screenshot 2019-08-23 at 12 15 56 PM" src="https://user-images.githubusercontent.com/47576037/63593595-2e19cb80-c5ac-11e9-9295-07ab3015da18.png">

- Adding 16 Tags
<img width="1680" alt="Screenshot 2019-08-23 at 12 18 21 PM" src="https://user-images.githubusercontent.com/47576037/63593547-13475700-c5ac-11e9-8713-0728459c8808.png">
