### PR TITLE
Add Social Login Redirect URLs

### DIFF
--- a/server/controllers/Auth.js
+++ b/server/controllers/Auth.js
@@ -1,9 +1,4 @@
-import {
-  getUserAgent,
-  createSocialUsers,
-  serverResponse,
-  getSocialUserData
-} from '../helpers';
+import { getUserAgent, createSocialUsers, getSocialUserData } from '../helpers';
 /**
  * @export
  * @class Auth
@@ -32,7 +27,9 @@ class Auth {
     };
     const user = await createSocialUsers(data);
     delete user.password;
-    serverResponse(response, 200, user);
+    response
+      .status(301)
+      .redirect(`${process.env.CLIENT_URL}?token=${user.token}&email=${email}`);
   }
 }
 export default Auth;

--- a/server/controllers/Profiles.js
+++ b/server/controllers/Profiles.js
@@ -86,10 +86,18 @@ class Profiles {
   static async view(req, res) {
     try {
       const {
-        params: { username },
+        params: { userDetail },
         headers: { authorization }
       } = req;
-      const userProfile = await User.findByUsername(username);
+
+      let userProfile;
+
+      if (/.+@.+\.[A-Za-z]+$/.test(userDetail)) {
+        userProfile = await User.findByEmail(userDetail);
+      } else {
+        userProfile = await User.findByUsername(userDetail);
+      }
+
       if (!userProfile) {
         return serverResponse(res, 404, { error: 'user does not exist' });
       }

--- a/server/routes/auth.js
+++ b/server/routes/auth.js
@@ -6,11 +6,16 @@ import Auth from '../controllers/Auth';
 
 const auth = express.Router();
 
+const { CLIENT_URL } = process.env;
+
 Passport(auth);
 auth.get('/facebook', passport.authenticate('facebook', { scope: ['email'] }));
 auth.get(
   '/facebook/callback',
-  passport.authenticate('facebook', { session: false, failureRedirect: '/' }),
+  passport.authenticate('facebook', {
+    session: false,
+    failureRedirect: `${CLIENT_URL}/login`
+  }),
   PassportError.passportErrors,
   Auth.socialLogin
 );
@@ -21,7 +26,7 @@ auth.get(
 
 auth.get(
   '/google/callback',
-  passport.authenticate('google', { failureRedirect: '/' }),
+  passport.authenticate('google', { failureRedirect: `${CLIENT_URL}/login` }),
   Auth.socialLogin
 );
 
@@ -29,7 +34,7 @@ auth.get('/twitter', passport.authenticate('twitter'));
 
 auth.get(
   '/twitter/callback',
-  passport.authenticate('twitter', { failureRedirect: '/' }),
+  passport.authenticate('twitter', { failureRedirect: `${CLIENT_URL}/login` }),
   Auth.socialLogin
 );
 

--- a/server/routes/profile.js
+++ b/server/routes/profile.js
@@ -22,6 +22,6 @@ route.patch(
   Profiles.update
 );
 
-route.get('/:username', Profiles.view);
+route.get('/:userDetail', Profiles.view);
 
 export default route;

--- a/test/auth/facebook.test.js
+++ b/test/auth/facebook.test.js
@@ -64,14 +64,20 @@ describe('facebook login test', () => {
     sinon.assert.calledOnce(json);
   });
   it('register a new user sucessfully', async () => {
-    const res = { status() {}, json() {} };
-    const status = sinon.stub(res, 'status').returnsThis();
-    const json = sinon.stub(res, 'json').returnsThis();
+    const res = {
+      status() {
+        return '302';
+      },
+      json() {},
+      redirect() {}
+    };
     const Sessions = sinon.stub(Session, 'create').returns(false);
     const findOrCreate = sinon.stub(User, 'findOrCreate').returns(users);
+    const redirect = sinon.stub(res, 'redirect').returnsThis();
+    const status = sinon.stub(res, 'status').returnsThis();
     await Auth.socialLogin(request, res);
-    sinon.assert.calledOnce(status);
-    sinon.assert.calledOnce(json);
+    sinon.assert.calledOnce(redirect);
+    expect(status).to.calledWith(301);
     Sessions.restore();
     findOrCreate.restore();
   });

--- a/test/auth/google.test.js
+++ b/test/auth/google.test.js
@@ -23,14 +23,20 @@ const res = {
   status(responseStatus) {
     this.statusCode = responseStatus;
     return this;
+  },
+  redirect(url) {
+    this.statusCode = url;
+    return this;
   }
 };
 describe('google login test', () => {
   it('logs in such user successfully', async () => {
     const Sessions = sinon.stub(Session, 'create').returns(false);
     const findOrCreate = sinon.stub(User, 'findOrCreate').returns(users);
+    const redirect = sinon.stub(res, 'redirect').returnsThis();
     await Auth.socialLogin(request2, res);
-    expect(res.statusCode).to.equals(200);
+    sinon.assert.calledOnce(redirect);
+    expect(res.statusCode).to.equals(301);
     Sessions.restore();
     findOrCreate.restore();
   });

--- a/test/auth/twitter.test.js
+++ b/test/auth/twitter.test.js
@@ -23,6 +23,10 @@ const res = {
   status(responseStatus) {
     this.statusCode = responseStatus;
     return this;
+  },
+  redirect(url) {
+    this.statusCode = url;
+    return this;
   }
 };
 describe('twitter login test', () => {
@@ -30,8 +34,10 @@ describe('twitter login test', () => {
     it('logs in such user successfully', async () => {
       const Sessions = sinon.stub(Session, 'create').returns(false);
       const findOrCreate = sinon.stub(User, 'findOrCreate').returns(users);
+      const redirect = sinon.stub(res, 'redirect').returnsThis();
       await Auth.socialLogin(request3, res);
-      expect(res.statusCode).to.equals(200);
+      sinon.assert.calledOnce(redirect);
+      expect(res.statusCode).to.equals(301);
       Sessions.restore();
       findOrCreate.restore();
     });

--- a/test/profiles/view.test.js
+++ b/test/profiles/view.test.js
@@ -56,11 +56,35 @@ describe('GET Profile', () => {
     });
   });
 
-  context('when a visitor checks other users profile', () => {
+  context('when a visitor checks other users profile by username', () => {
     it('returns the user profile', async () => {
       const response = await chai
         .request(app)
         .get(`${baseUrl}/profiles/Jhayeuiui`);
+      expect(response).to.have.status(200);
+      expect(response.body.user).to.have.any.keys(
+        'firstName',
+        'lastName',
+        'userName',
+        'identifiedBy',
+        'avatarUrl',
+        'bio',
+        'followingsCount',
+        'followersCount'
+      );
+      expect(response.body.user).to.not.have.property(
+        'password',
+        'occupation',
+        'location'
+      );
+    });
+  });
+
+  context('when a visitor checks other users profile by email', () => {
+    it('returns the user profile', async () => {
+      const response = await chai
+        .request(app)
+        .get(`${baseUrl}/profiles/lucasi.jz@andela.com`);
       expect(response).to.have.status(200);
       expect(response.body.user).to.have.any.keys(
         'firstName',


### PR DESCRIPTION
#### What does this PR do?
- It adds redirect URLs for social login

#### Description of Task proposed in this pull request?
- A success redirect URL was added to the social auth controller

- A failure redirect URL was added to the social auth route

- Tokens generated on successful authentication were appended to the redirect URL for use on the frontend

#### How should this be manually tested (Quality Assurance)?
- On a successful `GET` request to any of the social providers, the application no longer ends at the backend. It redirects the user to the frontend.

#### Any background context you want to add (Operations Impact)?
- To use this API effectively, a `CLIENT_URL` should be added to the environment variables. This will allow the API to redirect your social login users to any URL you specify after they have been authenticated successfully.

#### What I have learned working on this feature: 
- I have learned how to redirect users properly and how social login works under the hood

